### PR TITLE
fixed log message when historic input tables are not matching

### DIFF
--- a/src/connectors/Connector.py
+++ b/src/connectors/Connector.py
@@ -257,7 +257,7 @@ class Connector(ABC):
                 ).lower()
                 assert self.check_table_entry_in_material_registry(
                     session, feature_table_query
-                )
+                ), f"Material table {feature_table_query} does not exist"
 
             if label_material_seq_no is not None:
                 label_table_query = utils.replace_seq_no_in_query(
@@ -265,13 +265,12 @@ class Connector(ABC):
                 ).lower()
                 assert self.check_table_entry_in_material_registry(
                     session, label_table_query
-                )
+                ), f"Material table {label_table_query} does not exist"
 
             return True
-        except:
-            logger.info(
-                f"{material_table_query} is not materialized for one of the"
-                "seq nos '{feature_material_seq_no}', '{label_material_seq_no}'"
+        except AssertionError as e:
+            logger.debug(
+                f"{e}. Skipping the sequence tuple {feature_material_seq_no, label_material_seq_no} as it is not valid"
             )
             return False
 

--- a/tests/unit/RedshiftConnector.py
+++ b/tests/unit/RedshiftConnector.py
@@ -672,5 +672,5 @@ class TestValidateHistoricalMaterialsHash(unittest.TestCase):
         result = self.connector.validate_historical_materials_hash(
             self.session_mock, "SELECT * FROM material_table_3", 1, 2
         )
-        # Assert the result is True
+        # Assert the result is False
         self.assertFalse(result)

--- a/tests/unit/RedshiftConnector.py
+++ b/tests/unit/RedshiftConnector.py
@@ -636,3 +636,41 @@ class TestValidations(unittest.TestCase):
         )
         self.assertTrue(self.connector.validate_columns_are_present(table, "COL1"))
         self.assertTrue(self.connector.validate_label_distinct_values(table, "COL1"))
+
+
+class TestValidateHistoricalMaterialsHash(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session_mock = Mock()
+        self.connector = RedshiftConnector("data")
+        self.material_table = "material_table"
+        self.start_date = "2022-01-01"
+        self.end_date = "2022-01-31"
+        self.features_profiles_model = "model_name"
+        self.model_hash = "model_hash"
+        self.prediction_horizon_days = 7
+        self.output_filename = "output_file.csv"
+        self.site_config_path = "siteconfig.yaml"
+        self.project_folder = "project_folder"
+        self.input_models = ["model1.yaml", "model2.yaml"]
+        self.inputs = ["""select * from material_user_var_736465_0"""]
+
+    # The method is called with valid arguments and all tables exist in the warehouse registry.
+    def test_valid_arguments_all_tables_exist(self):
+        self.connector.check_table_entry_in_material_registry = Mock(return_value=True)
+        # Call the method
+        result = self.connector.validate_historical_materials_hash(
+            self.session_mock, "SELECT * FROM material_table_3", 1, 2
+        )
+        # Assert the result is True
+        self.assertTrue(result)
+
+    def test_valid_arguments_some_tables_dont_exist(self):
+        self.connector.check_table_entry_in_material_registry = Mock(
+            side_effect=[True, False]
+        )
+        # Call the method
+        result = self.connector.validate_historical_materials_hash(
+            self.session_mock, "SELECT * FROM material_table_3", 1, 2
+        )
+        # Assert the result is True
+        self.assertFalse(result)


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
