### PR TITLE
Bug/onehot encoder binned categories

### DIFF
--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
@@ -311,6 +311,17 @@ if __name__ == "__main__":
     if isinstance(material_info_[0], list):
         for material in material_info_:
             material_info.append(constants.TrainTablesInfo(*material))
+    import logging
+
+    file_handler = logging.FileHandler(
+        os.path.join(output_dir, "preprocess_and_train.log")
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
 
     train_results_json = preprocess_and_train(
         train_procedure,

--- a/src/predictions/rudderstack_predictions/utils/utils.py
+++ b/src/predictions/rudderstack_predictions/utils/utils.py
@@ -904,13 +904,9 @@ def plot_top_k_feature_importance(
             "Got 3D numpy array with last dimension having depth of 2. Taking the second output for plotting feature importance"
         )
         shap_values = shap_values[:, :, 1]
-    onehot_encoder = (
-        dict(pipe.steps)["preprocessor"]
-        .named_transformers_["cat"]
-        .named_steps["encoder"]
-    )
     onehot_encoder_columns = get_onehot_encoded_col_names(
-        onehot_encoder, categorical_columns
+        dict(pipe.steps)["preprocessor"].transformers_[1][1].named_steps["encoder"],
+        categorical_columns,
     )
     col_names_ = (
         numeric_columns

--- a/tests/integration/redshift/classifier.py
+++ b/tests/integration/redshift/classifier.py
@@ -9,7 +9,6 @@ from src.predictions.rudderstack_predictions.connectors.RedshiftConnector import
 from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
 import json
 
-
 creds = json.loads(os.environ["REDSHIFT_SITE_CONFIG"])
 creds["schema"] = "rs_profiles_3"
 
@@ -127,6 +126,7 @@ def validate_reports():
         "02-test-lift-chart",
         "03-test-pr-auc",
         "04-test-roc-auc",
+        "preprocess_and_train.log",
     ]
     files = os.listdir(reports_directory)
     missing_files = []


### PR DESCRIPTION
## Description of the change

1. Handled a bug where if onehot encoder has capped category count and that's triggered, the column names were earlier captured incorrectly.
2. Added a preprocessor_and_train log file so the module  2 logs are captured in outputs directory for better debuggability

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
