### PR TITLE
raise exc. while writing if table is not present

### DIFF
--- a/src/predictions/rudderstack_predictions/connectors/wh/bigquery_base_connector.py
+++ b/src/predictions/rudderstack_predictions/connectors/wh/bigquery_base_connector.py
@@ -43,11 +43,4 @@ class BigqueryConnector(ConnectorBase):
 
         except Exception as e:
             logger.error(f"Error while writing to warehouse: {e}")
-
-            # Check for non-existing schema
-            err_str = f"table '{table_name}' does not exist".lower()
-            if err_str in str(e).lower():
-                self.create_table(df, table_name, schema)
-                # Try again`
-                logger.info("Trying again")
-                self.write_to_table(df, table_name, schema, if_exists)
+            raise Exception(f"Error while writing to warehouse: {e}")

--- a/src/predictions/rudderstack_predictions/connectors/wh/redshift_base_connector.py
+++ b/src/predictions/rudderstack_predictions/connectors/wh/redshift_base_connector.py
@@ -87,12 +87,5 @@ class RedShiftConnector(ConnectorBase):
                     f"Successfully wrote table {table_name} to S3 and then to Redshift"
                 )
         except Exception as e:
-            # Check for non existing schema
-            if "cannot copy into nonexistent table" in str(e).lower():
-                logger.info(f"{table_name} not found. Creating it")
-                self.create_table(df, table_name, schema)
-                # Try again
-                logger.info("Trying again")
-                self.write_to_table(df, table_name, schema, if_exists)
-            else:
-                raise e
+            logger.error(f"Error while writing to warehouse: {e}")
+            raise Exception(f"Error while writing to warehouse: {e}")


### PR DESCRIPTION
## Description of the change

> warehouse connector's `write_to_table()` was also creating the table if it doesn't exist. But this shouldn't happen in ideal case.
> It's being used to write metrics dataframe and final predictions dataframe.
> Metric table name is also passed to train script from profiles. So, That's also unique and it's existing case is already considered.
> Removal of writing feature_importance dataframe to warehouse has already been handled in PR (#268 ).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
