### PR TITLE
removing unnecesaary table uploads to warehouse

### DIFF
--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
@@ -72,7 +72,8 @@ def train_and_store_model_results(
     figure_file = connector.join_file_path(
         trainer.figure_names["feature-importance-chart"]
     )
-    shap_importance = utils.plot_top_k_feature_importance(
+    logger.info(f"Generating feature importance plot")
+    utils.plot_top_k_feature_importance(
         pipe,
         train_x,
         figure_file,

--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
@@ -78,7 +78,6 @@ def train_and_store_model_results(
         figure_file,
         top_k_features=20,
     )
-    connector.write_pandas(shap_importance, "FEATURE_IMPORTANCE", if_exists="replace")
     metrics_df, create_metrics_table_query = connector.fetch_create_metrics_table_query(
         metrics_df,
         metrics_table,

--- a/src/predictions/rudderstack_predictions/train.py
+++ b/src/predictions/rudderstack_predictions/train.py
@@ -210,13 +210,6 @@ def _train(
                     figure_file,
                     top_k_features=20,
                 )
-                connector.write_pandas(
-                    shap_importance,
-                    "FEATURE_IMPORTANCE",
-                    session=session,
-                    auto_create_table=True,
-                    overwrite=True,
-                )
                 connector.save_file(session, figure_file, stage_name, overwrite=True)
             except Exception as e:
                 logger.error(f"Could not generate plots {e}")

--- a/src/predictions/rudderstack_predictions/train.py
+++ b/src/predictions/rudderstack_predictions/train.py
@@ -204,7 +204,8 @@ def _train(
                 figure_file = os.path.join(
                     "tmp", trainer.figure_names["feature-importance-chart"]
                 )
-                shap_importance = utils.plot_top_k_feature_importance(
+                logger.info(f"Generating feature importance plot")
+                utils.plot_top_k_feature_importance(
                     pipe,
                     train_x,
                     figure_file,

--- a/src/predictions/rudderstack_predictions/utils/utils.py
+++ b/src/predictions/rudderstack_predictions/utils/utils.py
@@ -769,7 +769,6 @@ def plot_top_k_feature_importance(
     plt.title(f"Top {top_k_features} Important Features")
     plt.savefig(figure_file, bbox_inches="tight")
     plt.clf()
-    return shap_importance
 
 
 def fetch_staged_file(


### PR DESCRIPTION
## Description of the change

> In addition to feature_importance chart, we were also writing feature_importance table to warehouse. But this was never being used further, neither in code nor in UI. Written table destination is also same which can result in unnecessary conflicts if multiple projects run in same schema.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
