### PR TITLE
Feature/prml 479 better error message for invalid rows in date time

### DIFF
--- a/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
@@ -632,21 +632,35 @@ class CommonWarehouseConnector(Connector):
         label_column: str,
     ) -> bool:
         distinct_values_count_list = feature_table[label_column].value_counts()
+        num_distinct_values = len(distinct_values_count_list)
+        req_distinct_values = constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES
         if (
-            len(distinct_values_count_list)
-            < constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES
+            num_distinct_values
+            < req_distinct_values
         ):
             raise Exception(
-                f"Label column {label_column} has invalid number of distinct values. \
-                    Please check if the label column has valid labels."
+                f"Label column {label_column} has {num_distinct_values} of distinct values while we expect minimum {req_distinct_values} values for a regression problem.\
+                    Please check your label column and modify task in your python model to 'classification' if that's a better fit. "
             )
         return True
+    
 
     def add_days_diff(
         self, table: pd.DataFrame, new_col: str, time_col: str, end_ts: str
     ) -> pd.DataFrame:
         """Adds a new column to the given table containing the difference in days between the given timestamp columns."""
-        table["temp_1"] = pd.to_datetime(table[time_col]).dt.tz_localize(None)
+        try:
+            table["temp_1"] = pd.to_datetime(table[time_col]).dt.tz_localize(None)
+        except pd.errors.OutOfBoundsDatetime as e:
+            min_ts = pd.Timestamp.min
+            max_ts = pd.Timestamp.max
+            invalid_rows_count = ((table[time_col] < min_ts) | (table[time_col] > max_ts)).sum()
+
+            raise ValueError( f"{time_col} entity var has timestamp values outside the acceptable range of {min_ts} and {max_ts}.  \
+                              This may be due to some data corruption in source tables or an error in the entity var definition.  \
+                              You can exclude these users for training using the eligible_users flag.  \
+                              Total rows with invalid {time_col} values: {invalid_rows_count}"
+            )
         table["temp_2"] = pd.to_datetime(end_ts)
         table[new_col] = (table["temp_2"] - table["temp_1"]).dt.days
         return table.drop(columns=["temp_1", "temp_2"])

--- a/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
@@ -634,16 +634,12 @@ class CommonWarehouseConnector(Connector):
         distinct_values_count_list = feature_table[label_column].value_counts()
         num_distinct_values = len(distinct_values_count_list)
         req_distinct_values = constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES
-        if (
-            num_distinct_values
-            < req_distinct_values
-        ):
+        if num_distinct_values < req_distinct_values:
             raise Exception(
                 f"Label column {label_column} has {num_distinct_values} of distinct values while we expect minimum {req_distinct_values} values for a regression problem.\
                     Please check your label column and modify task in your python model to 'classification' if that's a better fit. "
             )
         return True
-    
 
     def add_days_diff(
         self, table: pd.DataFrame, new_col: str, time_col: str, end_ts: str
@@ -654,9 +650,12 @@ class CommonWarehouseConnector(Connector):
         except pd.errors.OutOfBoundsDatetime as e:
             min_ts = pd.Timestamp.min
             max_ts = pd.Timestamp.max
-            invalid_rows_count = ((table[time_col] < min_ts) | (table[time_col] > max_ts)).sum()
+            invalid_rows_count = (
+                (table[time_col] < min_ts) | (table[time_col] > max_ts)
+            ).sum()
 
-            raise ValueError( f"{time_col} entity var has timestamp values outside the acceptable range of {min_ts} and {max_ts}.  \
+            raise ValueError(
+                f"{time_col} entity var has timestamp values outside the acceptable range of {min_ts} and {max_ts}.  \
                               This may be due to some data corruption in source tables or an error in the entity var definition.  \
                               You can exclude these users for training using the eligible_users flag.  \
                               Total rows with invalid {time_col} values: {invalid_rows_count}"

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -761,9 +761,8 @@ class SnowflakeConnector(Connector):
         distinct_values_count = feature_table.groupBy(label_column).count()
         num_distinct_values = distinct_values_count.count()
         req_distinct_values = int(constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES)
-        if  num_distinct_values < req_distinct_values :
+        if num_distinct_values < req_distinct_values:
             raise Exception(
-                
                 f"Label column {label_column} has {num_distinct_values} of distinct values while we expect minimum {req_distinct_values} values for a regression problem.\
                     Please check your label column and modify task in your python model to 'classification' if that's a better fit. "
             )

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -759,12 +759,13 @@ class SnowflakeConnector(Connector):
         self, feature_table: snowflake.snowpark.Table, label_column: str
     ) -> bool:
         distinct_values_count = feature_table.groupBy(label_column).count()
-        if distinct_values_count.count() < int(
-            constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES
-        ):
+        num_distinct_values = distinct_values_count.count()
+        req_distinct_values = int(constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES)
+        if  num_distinct_values < req_distinct_values :
             raise Exception(
-                f"Label column {label_column} has invalid number of distinct values. \
-                    Please check if the label column has valid labels."
+                
+                f"Label column {label_column} has {num_distinct_values} of distinct values while we expect minimum {req_distinct_values} values for a regression problem.\
+                    Please check your label column and modify task in your python model to 'classification' if that's a better fit. "
             )
         return True
 

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -763,7 +763,7 @@ class SnowflakeConnector(Connector):
         req_distinct_values = int(constants.REGRESSOR_MIN_LABEL_DISTINCT_VALUES)
         if num_distinct_values < req_distinct_values:
             raise Exception(
-                f"Label column {label_column} has {num_distinct_values} of distinct values while we expect minimum {req_distinct_values} values for a regression problem.\
+                f"Label column {label_column} has {num_distinct_values} distinct values while we expect minimum {req_distinct_values} values for a regression problem.\
                     Please check your label column and modify task in your python model to 'classification' if that's a better fit. "
             )
         return True

--- a/tests/unit/RedshiftConnector.py
+++ b/tests/unit/RedshiftConnector.py
@@ -571,11 +571,13 @@ class TestValidations(unittest.TestCase):
         label_column = "COL1"
         with self.assertRaises(Exception) as context:
             self.connector.validate_label_distinct_values(self.table, label_column)
-        self.assertIn(
-            f"Label column {label_column} has invalid number of distinct values.",
-            str(context.exception),
-            [],
-        )
+            distinct_values_count = self.table.groupBy(label_column).count()
+            num_distinct_values = distinct_values_count.count()
+            self.assertIn(
+                f"Label column {label_column} has {num_distinct_values} distinct values",
+                str(context.exception),
+                [],
+            )
 
     @patch(
         "src.predictions.rudderstack_predictions.utils.constants.CLASSIFIER_MIN_LABEL_PROPORTION",

--- a/tests/unit/SnowflakeConnector.py
+++ b/tests/unit/SnowflakeConnector.py
@@ -144,8 +144,10 @@ class TestValidations(unittest.TestCase):
         label_column = "COL1"
         with self.assertRaises(Exception) as context:
             self.connector.validate_label_distinct_values(self.table, label_column)
+            distinct_values_count = self.table.groupBy(label_column).count()
+            num_distinct_values = distinct_values_count.count()
         self.assertIn(
-            f"Label column {label_column} has invalid number of distinct values.",
+            f"Label column {label_column} has {num_distinct_values} distinct values",
             str(context.exception),
             [],
         )

--- a/tests/unit/SnowflakeConnector.py
+++ b/tests/unit/SnowflakeConnector.py
@@ -146,11 +146,11 @@ class TestValidations(unittest.TestCase):
             self.connector.validate_label_distinct_values(self.table, label_column)
             distinct_values_count = self.table.groupBy(label_column).count()
             num_distinct_values = distinct_values_count.count()
-        self.assertIn(
-            f"Label column {label_column} has {num_distinct_values} distinct values",
-            str(context.exception),
-            [],
-        )
+            self.assertIn(
+                f"Label column {label_column} has {num_distinct_values} distinct values",
+                str(context.exception),
+                [],
+            )
 
     @patch(
         "src.predictions.rudderstack_predictions.utils.constants.CLASSIFIER_MIN_LABEL_PROPORTION",


### PR DESCRIPTION
Modified error messages in validate_label_distinct_values in SnowflakeConnector.py and CommonWarehouseConnector.py.
Added exception block in add_days_diff in CommonWarehouseConnector.py.
Modified unit test test_expects_error_if_label_count_is_low_regression so that it matches with the error message in SnowflakeConnector.py , RedshiftConnector.py