### PR TITLE
refactor: move session object inside connector class

### DIFF
--- a/src/predictions/rudderstack_predictions/connectors/BigQueryConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/BigQueryConnector.py
@@ -11,7 +11,7 @@ from .CommonWarehouseConnector import CommonWarehouseConnector
 
 
 class BigQueryConnector(CommonWarehouseConnector):
-    def __init__(self, folder_path: str) -> None:
+    def __init__(self, creds, folder_path: str) -> None:
         data_type_mapping = {
             "numeric": (
                 "INT",
@@ -30,7 +30,7 @@ class BigQueryConnector(CommonWarehouseConnector):
             "timestamp": ("DATE", "TIME", "DATETIME", "TIMESTAMP", "INTERVAL"),
             "arraytype": ("ARRAY",),
         }
-        super().__init__(folder_path, data_type_mapping)
+        super().__init__(creds, folder_path, data_type_mapping)
 
     def build_session(self, credentials: dict) -> google.cloud.bigquery.client.Client:
         self.schema = credentials.get("schema", None)
@@ -48,37 +48,33 @@ class BigQueryConnector(CommonWarehouseConnector):
         )
         return session
 
-    def run_query(
-        self, session: google.cloud.bigquery.client.Client, query: str, response=True
-    ) -> Optional[List]:
+    def run_query(self, query: str, response=True) -> Optional[List]:
         """Runs the given query on the bigquery connection and returns a list with Named indices."""
         try:
             if response:
                 return list(
-                    session.query_and_wait(query).to_dataframe().itertuples(index=False)
+                    self.session.query_and_wait(query)
+                    .to_dataframe()
+                    .itertuples(index=False)
                 )
             else:
-                return session.query_and_wait(query)
+                return self.session.query_and_wait(query)
         except Exception as e:
             raise Exception(f"Couldn't run the query: {query}. Error: {str(e)}")
 
     def get_table_as_dataframe(
-        self, session: google.cloud.bigquery.client.Client, table_name: str, **kwargs
+        self, _: google.cloud.bigquery.client.Client, table_name: str, **kwargs
     ) -> pd.DataFrame:
         query = self._create_get_table_query(table_name, **kwargs)
-        return session.query_and_wait(query).to_dataframe()
+        return self.session.query_and_wait(query).to_dataframe()
 
-    def get_tablenames_from_schema(
-        self, session: google.cloud.bigquery.client.Client
-    ) -> pd.DataFrame:
+    def get_tablenames_from_schema(self) -> pd.DataFrame:
         query = f"SELECT DISTINCT table_name as tablename FROM `{self.project_id}.{self.schema}.INFORMATION_SCHEMA.TABLES`;"
-        return session.query_and_wait(query).to_dataframe()
+        return self.session.query_and_wait(query).to_dataframe()
 
-    def fetch_table_metadata(
-        self, session: google.cloud.bigquery.client.Client, table_name: str
-    ) -> List:
+    def fetch_table_metadata(self, table_name: str) -> List:
         """Fetches the schema fields of the given table from the BigQuery schema."""
-        schema = session.get_table(
+        schema = self.session.get_table(
             f"{self.project_id}.{self.schema}.{table_name}"
         ).schema
         return schema

--- a/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
@@ -445,9 +445,9 @@ class CommonWarehouseConnector(Connector):
         return int(seq_no)
 
     def get_model_hash_from_registry(
-        self, session, material_table: str, model_name: str, seq_no: int
+        self, material_table: str, model_name: str, seq_no: int
     ) -> str:
-        material_registry_df = self.get_material_registry_table(session, material_table)
+        material_registry_df = self.get_material_registry_table(material_table)
         try:
             temp_hash_vector = (
                 material_registry_df.query(f'model_name == "{model_name}"')

--- a/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
@@ -19,7 +19,8 @@ local_folder = constants.LOCAL_STORAGE_DIR
 
 
 class CommonWarehouseConnector(Connector):
-    def __init__(self, folder_path: str, data_type_mapping: dict) -> None:
+    def __init__(self, creds: dict, folder_path: str, data_type_mapping: dict) -> None:
+        super().__init__(creds)
         self.local_dir = os.path.join(folder_path, local_folder)
         path = Path(self.local_dir)
         path.mkdir(parents=True, exist_ok=True)
@@ -126,23 +127,21 @@ class CommonWarehouseConnector(Connector):
     def compute_udf_name(self, model_path: str) -> None:
         return
 
-    def is_valid_table(self, session, table_name: str) -> bool:
+    def is_valid_table(self, table_name: str) -> bool:
         try:
-            self.run_query(session, f"select * from {table_name} limit 1")
+            self.run_query(f"select * from {table_name} limit 1")
             return True
         except:
             return False
 
     def check_table_entry_in_material_registry(
-        self, session, registry_table_name: str, material: dict
+        self, registry_table_name: str, material: dict
     ) -> bool:
         """
         Checks wether an entry is there in the material registry for the given
         material table name and wether its sucessfully materialised or not as well
         """
-        material_registry_table = self.get_material_registry_table(
-            session, registry_table_name
-        )
+        material_registry_table = self.get_material_registry_table(registry_table_name)
         result = material_registry_table.loc[
             (material_registry_table["model_name"] == material["model_name"])
             & (material_registry_table["model_hash"] == material["model_hash"])
@@ -151,9 +150,9 @@ class CommonWarehouseConnector(Connector):
         row_count = result.shape[0]
         return row_count != 0
 
-    def get_table(self, session, table_name: str, **kwargs) -> pd.DataFrame:
+    def get_table(self, table_name: str, **kwargs) -> pd.DataFrame:
         """Fetches the table with the given name from the schema as a pandas Dataframe object."""
-        return self.get_table_as_dataframe(session, table_name, **kwargs)
+        return self.get_table_as_dataframe(self.session, table_name, **kwargs)
 
     def _create_get_table_query(self, table_name, **kwargs):
         filter_condition = kwargs.get("filter_condition", "")
@@ -192,7 +191,6 @@ class CommonWarehouseConnector(Connector):
 
     def label_table(
         self,
-        session,
         label_table_name: str,
         label_column: str,
         entity_column: str,
@@ -203,7 +201,7 @@ class CommonWarehouseConnector(Connector):
         def _replace_na(value):
             return np.nan if pd.isna(value) else value
 
-        feature_table = self.get_table(session, label_table_name)
+        feature_table = self.get_table(label_table_name)
         if label_value is not None:
             feature_table = feature_table.applymap(_replace_na)
             feature_table[label_column] = np.where(
@@ -305,10 +303,10 @@ class CommonWarehouseConnector(Connector):
         return high_cardinal_features
 
     def get_default_label_value(
-        self, session, table_name: str, label_column: str, positive_boolean_flags: list
+        self, table_name: str, label_column: str, positive_boolean_flags: list
     ):
         label_value = list()
-        table = self.get_table(session, table_name)
+        table = self.get_table(table_name)
         distinct_labels = table[label_column].unique()
 
         if len(distinct_labels) != 2:
@@ -351,7 +349,6 @@ class CommonWarehouseConnector(Connector):
 
     def join_feature_label_tables(
         self,
-        session,
         registry_table_name: str,
         entity_var_model_name: str,
         model_hash: str,
@@ -359,7 +356,7 @@ class CommonWarehouseConnector(Connector):
         end_time: str,
         prediction_horizon_days: int,
     ) -> Iterable:
-        df = self.get_material_registry_table(session, registry_table_name)
+        df = self.get_material_registry_table(registry_table_name)
         feature_df = self.fetch_filtered_table(
             df,
             entity_var_model_name,
@@ -406,13 +403,12 @@ class CommonWarehouseConnector(Connector):
 
     def get_creation_ts(
         self,
-        session,
         material_table: str,
         model_hash: str,
         entity_key: str,
     ):
         """Retrieves the latest creation timestamp for a specific model hash, and entity key."""
-        redshift_df = self.get_material_registry_table(session, material_table)
+        redshift_df = self.get_material_registry_table(material_table)
         try:
             temp_hash_vector = (
                 redshift_df.query(f'model_hash == "{model_hash}"')
@@ -430,9 +426,9 @@ class CommonWarehouseConnector(Connector):
         return creation_ts.tz_localize(None)
 
     def get_latest_seq_no_from_registry(
-        self, session, material_table: str, model_hash: str, model_name: str
+        self, material_table: str, model_hash: str, model_name: str
     ) -> int:
-        redshift_df = self.get_material_registry_table(session, material_table)
+        redshift_df = self.get_material_registry_table(material_table)
         try:
             temp_hash_vector = (
                 redshift_df.query(f'model_hash == "{model_hash}"')
@@ -469,10 +465,10 @@ class CommonWarehouseConnector(Connector):
         return model_hash
 
     def get_end_ts(
-        self, session, material_table, model_name: str, model_hash: str, seq_no: int
+        self, material_table, model_name: str, model_hash: str, seq_no: int
     ) -> str:
         """This function will return the end_ts with given model, model name and seq_no."""
-        df = self.get_material_registry_table(session, material_table)
+        df = self.get_material_registry_table(material_table)
 
         try:
             feature_table_info_df = (
@@ -499,7 +495,6 @@ class CommonWarehouseConnector(Connector):
 
     def fetch_staged_file(
         self,
-        session,
         stage_name: str,
         file_name: str,
         target_folder: str,
@@ -535,7 +530,6 @@ class CommonWarehouseConnector(Connector):
 
     def check_for_classification_data_requirement(
         self,
-        session,
         materials: List[constants.TrainTablesInfo],
         label_column: str,
         label_value: str,
@@ -554,14 +548,14 @@ class CommonWarehouseConnector(Connector):
                 INNER JOIN (SELECT * FROM {m.label_table_name}{where_condition}) b ON a.{entity_key} = b.{entity_key}
                 WHERE b.{label_column} != {label_value}"""
 
-            result = self.run_query(session, query_str, response=True)
+            result = self.run_query(query_str, response=True)
 
             if len(result) != 0:
                 total_negative_samples += result[0][0]
 
             query_str = f"""SELECT COUNT(*) as count
                 FROM {m.label_table_name}{where_condition}"""
-            result = self.run_query(session, query_str, response=True)
+            result = self.run_query(query_str, response=True)
 
             if len(result) != 0:
                 total_samples += result[0][0]
@@ -586,7 +580,6 @@ class CommonWarehouseConnector(Connector):
 
     def check_for_regression_data_requirement(
         self,
-        session,
         materials: List[constants.TrainTablesInfo],
         filter_condition: str = None,
     ) -> bool:
@@ -599,7 +592,7 @@ class CommonWarehouseConnector(Connector):
             feature_material = material.feature_table_name
             query_str = f"""SELECT COUNT(*) as count
                 FROM {feature_material}{where_condition}"""
-            result = self.run_query(session, query_str, response=True)
+            result = self.run_query(query_str, response=True)
 
             if len(result) != 0:
                 total_samples += result[0][0]
@@ -717,9 +710,9 @@ class CommonWarehouseConnector(Connector):
     ) -> List:
         return table[column_name].unique()
 
-    def get_tables_by_prefix(self, session, prefix: str):
+    def get_tables_by_prefix(self, prefix: str):
         tables = list()
-        registry_df = self.get_tablenames_from_schema(session)
+        registry_df = self.get_tablenames_from_schema()
 
         registry_df = registry_df[
             registry_df["tablename"].str.lower().str.startswith(f"{prefix.lower()}")
@@ -731,13 +724,12 @@ class CommonWarehouseConnector(Connector):
 
     def get_material_registry_table(
         self,
-        session,
         material_registry_table_name: str,
     ) -> pd.DataFrame:
         """Fetches and filters the material registry table to get only the successful runs. It assumes that the successful runs have a status of 2.
         Currently profiles creates a row at the start of a run with status 1 and creates a new row with status to 2 at the end of the run.
         """
-        material_registry_table = self.get_table(session, material_registry_table_name)
+        material_registry_table = self.get_table(material_registry_table_name)
 
         def safe_parse_json(entry):
             try:
@@ -838,32 +830,26 @@ class CommonWarehouseConnector(Connector):
             logger.info("Local directory not present")
             pass
 
-    def pre_job_cleanup(self, session) -> None:
+    def pre_job_cleanup(self) -> None:
         pass
 
-    def post_job_cleanup(self, session) -> None:
-        session.close()
+    def post_job_cleanup(self) -> None:
+        self.session.close()
 
     @abstractmethod
     def build_session(self, credentials: dict):
         pass
 
     @abstractmethod
-    def run_query(self, session, query: str, response: bool) -> Optional[Sequence]:
+    def run_query(self, query: str, response: bool) -> Optional[Sequence]:
         pass
 
     @abstractmethod
-    def fetch_table_metadata(self, session, table_name: str) -> List:
+    def get_table_as_dataframe(self, _, table_name: str, **kwargs) -> pd.DataFrame:
         pass
 
     @abstractmethod
-    def get_table_as_dataframe(
-        self, session, table_name: str, **kwargs
-    ) -> pd.DataFrame:
-        pass
-
-    @abstractmethod
-    def get_tablenames_from_schema(self, session) -> pd.DataFrame:
+    def get_tablenames_from_schema(self) -> pd.DataFrame:
         pass
 
     @abstractmethod

--- a/src/predictions/rudderstack_predictions/connectors/Connector.py
+++ b/src/predictions/rudderstack_predictions/connectors/Connector.py
@@ -110,8 +110,8 @@ class Connector(ABC):
 
     @abstractmethod
     def get_table_as_dataframe(
-        # session needs to passed as argument since the method is called from Snowpark procedure
         self,
+        # session is being passed as argument since "self.session" is not available in Snowpark stored procedure
         session,
         table_name: str,
         **kwargs
@@ -158,8 +158,8 @@ class Connector(ABC):
 
     @abstractmethod
     def save_file(
-        # session needs to passed as argument since the method is called from Snowpark procedure
         self,
+        # session is being passed as argument since "self.session" is not available in Snowpark stored procedure
         session,
         file_name: str,
         stage_name: str,

--- a/src/predictions/rudderstack_predictions/connectors/Connector.py
+++ b/src/predictions/rudderstack_predictions/connectors/Connector.py
@@ -245,7 +245,7 @@ class Connector(ABC):
 
     @abstractmethod
     def get_model_hash_from_registry(
-        self, session, material_table: str, model_name: str, seq_no: int
+        self, material_table: str, model_name: str, seq_no: int
     ) -> str:
         pass
 

--- a/src/predictions/rudderstack_predictions/connectors/Connector.py
+++ b/src/predictions/rudderstack_predictions/connectors/Connector.py
@@ -6,6 +6,9 @@ from ..utils import utils
 
 
 class Connector(ABC):
+    def __init__(self, creds: dict) -> None:
+        self.session = self.build_session(creds)
+
     def remap_credentials(self, credentials: dict) -> dict:
         """Remaps credentials from profiles siteconfig to the expected format for connection to warehouses"""
         new_creds = {
@@ -17,7 +20,6 @@ class Connector(ABC):
 
     def get_input_column_types(
         self,
-        session,
         trainer_obj,
         table_name: str,
         label_column: str,
@@ -26,7 +28,7 @@ class Connector(ABC):
     ) -> Dict:
         """Returns a dictionary containing the input column types with keys (numeric, categorical, arraytype, timestamp) for a given table."""
         lowercase_list = lambda features: [feature.lower() for feature in features]
-        schema_fields = self.fetch_table_metadata(session, table_name)
+        schema_fields = self.fetch_table_metadata(table_name)
 
         numeric_columns = utils.merge_lists_to_unique(
             self.get_numeric_features(schema_fields, label_column, entity_column),
@@ -85,7 +87,7 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def run_query(self, session, query: str, response: bool) -> Optional[Sequence]:
+    def run_query(self, query: str, response: bool) -> Optional[Sequence]:
         pass
 
     @abstractmethod
@@ -103,12 +105,16 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def get_table(self, session, table_name: str, **kwargs):
+    def get_table(self, table_name: str, **kwargs):
         pass
 
     @abstractmethod
     def get_table_as_dataframe(
-        self, session, table_name: str, **kwargs
+        # session needs to passed as argument since the method is called from Snowpark procedure
+        self,
+        session,
+        table_name: str,
+        **kwargs
     ) -> pd.DataFrame:
         pass
 
@@ -121,12 +127,12 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def is_valid_table(self, session, table_name) -> bool:
+    def is_valid_table(self, table_name) -> bool:
         pass
 
     @abstractmethod
     def check_table_entry_in_material_registry(
-        self, session, registry_table_name: str, material: dict
+        self, registry_table_name: str, material: dict
     ) -> bool:
         pass
 
@@ -143,7 +149,6 @@ class Connector(ABC):
     @abstractmethod
     def label_table(
         self,
-        session,
         label_table_name: str,
         label_column: str,
         entity_column: str,
@@ -153,12 +158,17 @@ class Connector(ABC):
 
     @abstractmethod
     def save_file(
-        self, session, file_name: str, stage_name: str, overwrite: bool
+        # session needs to passed as argument since the method is called from Snowpark procedure
+        self,
+        session,
+        file_name: str,
+        stage_name: str,
+        overwrite: bool,
     ) -> Any:
         pass
 
     @abstractmethod
-    def fetch_table_metadata(self, session, table_name: str) -> List:
+    def fetch_table_metadata(self, table_name: str) -> List:
         pass
 
     @abstractmethod
@@ -210,18 +220,17 @@ class Connector(ABC):
 
     @abstractmethod
     def get_default_label_value(
-        self, session, table_name: str, label_column: str, positive_boolean_flags: list
+        self, table_name: str, label_column: str, positive_boolean_flags: list
     ):
         pass
 
     @abstractmethod
-    def get_tables_by_prefix(self, session, prefix: str) -> str:
+    def get_tables_by_prefix(self, prefix: str) -> str:
         pass
 
     @abstractmethod
     def get_creation_ts(
         self,
-        session,
         material_table: str,
         model_hash: str,
         entity_key: str,
@@ -230,7 +239,7 @@ class Connector(ABC):
 
     @abstractmethod
     def get_latest_seq_no_from_registry(
-        self, session, material_table: str, model_hash: str, model_name: str
+        self, material_table: str, model_hash: str, model_name: str
     ) -> int:
         pass
 
@@ -243,7 +252,6 @@ class Connector(ABC):
     @abstractmethod
     def get_end_ts(
         self,
-        session,
         material_table: str,
         model_name: str,
         model_hash: str,
@@ -259,7 +267,7 @@ class Connector(ABC):
 
     @abstractmethod
     def fetch_staged_file(
-        self, session, stage_name: str, file_name: str, target_folder: str
+        self, stage_name: str, file_name: str, target_folder: str
     ) -> None:
         pass
 
@@ -279,7 +287,6 @@ class Connector(ABC):
     @abstractmethod
     def check_for_classification_data_requirement(
         self,
-        session,
         materials,
         label_column,
         label_value,
@@ -290,7 +297,7 @@ class Connector(ABC):
 
     @abstractmethod
     def check_for_regression_data_requirement(
-        self, session, materials, filter_condition
+        self, materials, filter_condition
     ) -> bool:
         pass
 
@@ -322,7 +329,7 @@ class Connector(ABC):
 
     @abstractmethod
     def get_material_registry_table(
-        self, session: Any, material_registry_table_name: str
+        self, material_registry_table_name: str
     ) -> pd.DataFrame:
         pass
 
@@ -355,17 +362,16 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def pre_job_cleanup(self, session) -> None:
+    def pre_job_cleanup(self) -> None:
         pass
 
     @abstractmethod
-    def post_job_cleanup(self, session) -> None:
+    def post_job_cleanup(self) -> None:
         pass
 
     @abstractmethod
     def join_feature_label_tables(
         self,
-        session,
         registry_table_name: str,
         entity_var_model_name: str,
         model_hash: str,

--- a/src/predictions/rudderstack_predictions/connectors/ConnectorFactory.py
+++ b/src/predictions/rudderstack_predictions/connectors/ConnectorFactory.py
@@ -11,8 +11,9 @@ except Exception as e:
 
 
 class ConnectorFactory:
-    def create(warehouse, creds: dict, folder_path: str = None) -> Connector:
+    def create(creds: dict, folder_path: str = None) -> Connector:
         connector = None
+        warehouse = creds["type"]
         if warehouse == "snowflake":
             connector = SnowflakeConnector(creds)
         elif warehouse == "redshift":

--- a/src/predictions/rudderstack_predictions/connectors/ConnectorFactory.py
+++ b/src/predictions/rudderstack_predictions/connectors/ConnectorFactory.py
@@ -11,14 +11,14 @@ except Exception as e:
 
 
 class ConnectorFactory:
-    def create(warehouse, folder_path: str = None) -> Connector:
+    def create(warehouse, creds: dict, folder_path: str = None) -> Connector:
         connector = None
         if warehouse == "snowflake":
-            connector = SnowflakeConnector()
+            connector = SnowflakeConnector(creds)
         elif warehouse == "redshift":
-            connector = RedshiftConnector(folder_path)
+            connector = RedshiftConnector(creds, folder_path)
         elif warehouse == "bigquery":
-            connector = BigQueryConnector(folder_path)
+            connector = BigQueryConnector(creds, folder_path)
         else:
             raise Exception(f"Invalid warehouse {warehouse}")
         return connector

--- a/src/predictions/rudderstack_predictions/connectors/RedshiftConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/RedshiftConnector.py
@@ -12,7 +12,7 @@ from .CommonWarehouseConnector import CommonWarehouseConnector
 
 
 class RedshiftConnector(CommonWarehouseConnector):
-    def __init__(self, folder_path: str) -> None:
+    def __init__(self, creds: dict, folder_path: str) -> None:
         data_type_mapping = {
             "numeric": (
                 "integer",
@@ -32,7 +32,7 @@ class RedshiftConnector(CommonWarehouseConnector):
             ),
             "arraytype": ("array",),
         }
-        super().__init__(folder_path, data_type_mapping)
+        super().__init__(creds, folder_path, data_type_mapping)
 
     def build_session(self, credentials: dict) -> redshift_connector.cursor.Cursor:
         self.schema = credentials.pop("schema")
@@ -49,36 +49,30 @@ class RedshiftConnector(CommonWarehouseConnector):
         session.execute(f"SET search_path TO {self.schema};")
         return session
 
-    def run_query(
-        self, session: redshift_connector.cursor.Cursor, query: str, response=True
-    ) -> Optional[Tuple]:
+    def run_query(self, query: str, response=True) -> Optional[Tuple]:
         """Runs the given query on the redshift connection and returns a Named Tuple."""
         if response:
-            return session.execute(query).fetchall()
+            return self.session.execute(query).fetchall()
         else:
-            return session.execute(query)
+            return self.session.execute(query)
 
     def get_table_as_dataframe(
-        self, session: redshift_connector.cursor.Cursor, table_name: str, **kwargs
+        self, _: redshift_connector.cursor.Cursor, table_name: str, **kwargs
     ) -> pd.DataFrame:
         query = self._create_get_table_query(table_name, **kwargs)
-        return session.execute(query).fetch_dataframe()
+        return self.session.execute(query).fetch_dataframe()
 
-    def get_tablenames_from_schema(
-        self, session: redshift_connector.cursor.Cursor
-    ) -> pd.DataFrame:
+    def get_tablenames_from_schema(self) -> pd.DataFrame:
         query = f"SELECT DISTINCT tablename FROM PG_TABLE_DEF WHERE schemaname = '{self.schema}';"
-        return session.execute(query).fetch_dataframe()
+        return self.session.execute(query).fetch_dataframe()
 
-    def fetch_table_metadata(
-        self, session: redshift_connector.cursor.Cursor, table_name: str
-    ) -> List:
+    def fetch_table_metadata(self, table_name: str) -> List:
         """Fetches the schema fields(column_name, data_type) tuple of the given table."""
         query = f"""SELECT column_name, data_type
                     FROM information_schema.columns
                     where table_schema='{self.schema}'
                         and table_name='{table_name.lower()}';"""
-        schema_list = self.run_query(session, query)
+        schema_list = self.run_query(query)
         schema_fields = namedtuple("schema_field", ["name", "field_type"])
         named_schema_list = [schema_fields(*row) for row in schema_list]
         return named_schema_list

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -610,7 +610,7 @@ class SnowflakeConnector(Connector):
     ) -> None:
         """Fetches a file from a Snowflake stage and saves it to a local target folder."""
         file_stage_path = f"{stage_name}/{file_name}"
-        self.get_file(self.session, file_stage_path, target_folder)
+        self.get_file(file_stage_path, target_folder)
         input_file_path = os.path.join(target_folder, f"{file_name}.gz")
         output_file_path = os.path.join(target_folder, file_name)
 
@@ -868,7 +868,6 @@ class SnowflakeConnector(Connector):
 
     def _delete_import_files(
         self,
-        _: snowflake.snowpark.Session,
         stage_name: str,
         import_paths: List[str],
     ) -> None:
@@ -884,7 +883,7 @@ class SnowflakeConnector(Connector):
                 self.run_query(f"remove @{row.name}")
 
     def _delete_procedures(
-        self, _: snowflake.snowpark.Session, procedure_name: str
+        self, procedure_name: str
     ) -> None:
         procedures = self.run_query(f"show procedures like '{procedure_name}'")
         for row in procedures:
@@ -895,7 +894,7 @@ class SnowflakeConnector(Connector):
             except Exception as e:
                 raise Exception(f"Error while dropping procedure {e}")
 
-    def _drop_fn_if_exists(self, _: snowflake.snowpark.Session, fn_name: str) -> bool:
+    def _drop_fn_if_exists(self, fn_name: str) -> bool:
         """Snowflake caches the functions and it reuses these next time. To avoid the caching,
         we manually search for the same function name and drop it before we create the udf.
         """
@@ -916,7 +915,6 @@ class SnowflakeConnector(Connector):
 
     def get_file(
         self,
-        _: snowflake.snowpark.Session,
         file_stage_path: str,
         target_folder: str,
     ):
@@ -941,11 +939,11 @@ class SnowflakeConnector(Connector):
 
     def _job_cleanup(self):
         if self.stored_procedure_name:
-            self._delete_procedures(self.session, self.stored_procedure_name)
+            self._delete_procedures(self.stored_procedure_name)
         if self.udf_name:
-            self._drop_fn_if_exists(self.session, self.udf_name)
+            self._drop_fn_if_exists(self.udf_name)
         if self.delete_files:
-            self._delete_import_files(self.session, self.stage_name, self.delete_files)
+            self._delete_import_files(self.stage_name, self.delete_files)
 
     def pre_job_cleanup(self):
         self._job_cleanup()

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -552,9 +552,9 @@ class SnowflakeConnector(Connector):
         return int(seq_no)
 
     def get_model_hash_from_registry(
-        self, session, material_table, model_name: str, seq_no: int
+        self, material_table, model_name: str, seq_no: int
     ) -> str:
-        material_registry_df = self.get_material_registry_table(session, material_table)
+        material_registry_df = self.get_material_registry_table(material_table)
 
         try:
             feature_table_info = (

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -882,9 +882,7 @@ class SnowflakeConnector(Connector):
             if any(substring in row.name for substring in import_files):
                 self.run_query(f"remove @{row.name}")
 
-    def _delete_procedures(
-        self, procedure_name: str
-    ) -> None:
+    def _delete_procedures(self, procedure_name: str) -> None:
         procedures = self.run_query(f"show procedures like '{procedure_name}'")
         for row in procedures:
             try:

--- a/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/SnowflakeConnector.py
@@ -139,7 +139,9 @@ class SnowflakeConnector(Connector):
     def get_table_as_dataframe(
         self, session: snowflake.snowpark.Session, table_name: str, **kwargs
     ) -> pd.DataFrame:
-        # Duplicating some code to avoid passing session as argument
+        # Duplicating "self.get_table()" function code here.
+        # This is because "get_table()"" uses "self.session" which is not available in case of Snowpark
+        # and I prefer duplicating 3 lines of code over changing the signature of multiple functions
         try:
             session.sql(f"select * from {table_name} limit 1").collect()
         except:

--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_predict.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_predict.py
@@ -242,7 +242,7 @@ if __name__ == "__main__":
     trainer = TrainerFactory.create(args.merged_config)
 
     wh_creds = utils.parse_warehouse_creds(args.wh_creds, args.mode)
-    connector = ConnectorFactory.create(wh_creds["type"], wh_creds, output_dir)
+    connector = ConnectorFactory.create(wh_creds, output_dir)
 
     model_path = os.path.join(output_dir, args.json_output_filename)
 

--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_predict.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_predict.py
@@ -36,7 +36,6 @@ def preprocess_and_predict(
     model_path,
     inputs,
     output_tablename,
-    session,
     connector,
     trainer: MLTrainer,
 ):
@@ -73,14 +72,13 @@ def preprocess_and_predict(
         raise Exception(f"Error while parsing seq_no from inputs: {inputs}. Error: {e}")
 
     whtService = PyNativeWHT(None)
-    whtService.init(connector, session, "", "")
+    whtService.init(connector, "", "")
 
     entity_var_table_name = whtService.compute_material_name(
         input_model_name, model_hash, seq_no
     )
 
     end_ts = connector.get_end_ts(
-        session,
         whtService.get_registry_table_name(),
         input_model_name,
         model_hash,
@@ -89,7 +87,7 @@ def preprocess_and_predict(
 
     logger.debug(f"Pulling data from Entity-Var table - {entity_var_table_name}")
     raw_data = connector.get_table(
-        session, entity_var_table_name, filter_condition=trainer.eligible_users
+        entity_var_table_name, filter_condition=trainer.eligible_users
     )
 
     logger.debug("Transforming timestamp columns.")
@@ -151,7 +149,7 @@ def preprocess_and_predict(
         udf_name = connector.udf_name
 
         @F.pandas_udf(
-            session=session,
+            session=connector.session,
             max_batch_size=10000,
             is_permanent=True,
             replace=True,
@@ -200,7 +198,7 @@ def preprocess_and_predict(
     )
     logger.debug("Closing the session")
 
-    connector.post_job_cleanup(session)
+    connector.post_job_cleanup()
     logger.debug("Finished Predict job")
 
 
@@ -244,8 +242,7 @@ if __name__ == "__main__":
     trainer = TrainerFactory.create(args.merged_config)
 
     wh_creds = utils.parse_warehouse_creds(args.wh_creds, args.mode)
-    connector = ConnectorFactory.create(wh_creds["type"], output_dir)
-    session = connector.build_session(wh_creds)
+    connector = ConnectorFactory.create(wh_creds["type"], wh_creds, output_dir)
 
     model_path = os.path.join(output_dir, args.json_output_filename)
 
@@ -255,7 +252,6 @@ if __name__ == "__main__":
         model_path,
         args.inputs,
         args.output_tablename,
-        session=session,
         connector=connector,
         trainer=trainer,
     )

--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
@@ -39,7 +39,6 @@ def train_and_store_model_results(
         overwrite corresponding values from model_configs.yaml file
         feature_table_column_types (dict): column types of the feature table
         From kwargs:
-            session (redshift_connector.cursor.Cursor): valid redshift session to access data warehouse
             connector (RedshiftConnector): RedshiftConnector object
             trainer (MLTrainer): MLTrainer object which has all the configs and methods required for training
 
@@ -47,12 +46,11 @@ def train_and_store_model_results(
         dict: returns the model_id which is basically the time converted to key at which results were generated
         along with precision, recall, fpr and tpr to generate pr-auc and roc-auc curve.
     """
-    session = kwargs.get("session")
     connector = kwargs.get("connector")
     trainer = kwargs.get("trainer")
-    if session is None or connector is None or trainer is None:
+    if connector is None or trainer is None:
         raise ValueError(
-            "session, connector and trainer are required in kwargs for training in Redshift"
+            "connector and trainer are required in kwargs for training in train_and_store_model_results"
         )
     numeric_columns = feature_table_column_types["numeric"]
     categorical_columns = feature_table_column_types["categorical"]
@@ -67,7 +65,7 @@ def train_and_store_model_results(
     )
     logger.info(f"Generating plots and saving them to the output directory.")
     trainer.plot_diagnostics(
-        connector, session, pipe, None, test_x, test_y, trainer.label_column
+        connector, connector.session, pipe, None, test_x, test_y, trainer.label_column
     )
     figure_file = connector.join_file_path(
         trainer.figure_names["feature-importance-chart"]
@@ -84,7 +82,6 @@ def train_and_store_model_results(
         metrics_table,
     )
     connector.run_query(
-        session,
         create_metrics_table_query,
         response=False,
     )
@@ -99,7 +96,6 @@ def prepare_feature_table(
 ):
     """Combines Feature table and Label table pairs, while converting all timestamp cols
     to numeric for creating a single table with user features and label."""
-    session = kwargs.get("session", None)
     connector = kwargs.get("connector", None)
     trainer = kwargs.get("trainer", None)
     try:
@@ -110,14 +106,14 @@ def prepare_feature_table(
         )
         if trainer.eligible_users:
             feature_table = connector.get_table(
-                session, feature_table_name, filter_condition=trainer.eligible_users
+                feature_table_name, filter_condition=trainer.eligible_users
             )
         else:
             default_user_shortlisting = (
                 f"{trainer.label_column} != {trainer.label_value}"
             )
             feature_table = connector.get_table(
-                session, feature_table_name, filter_condition=default_user_shortlisting
+                feature_table_name, filter_condition=default_user_shortlisting
             )
 
         feature_table = connector.drop_cols(feature_table, [trainer.label_column])
@@ -126,7 +122,7 @@ def prepare_feature_table(
             feature_table = connector.add_days_diff(
                 feature_table, col, col, feature_table_dt
             )
-        label_table = trainer.prepare_label_table(connector, session, label_table_name)
+        label_table = trainer.prepare_label_table(connector, label_table_name)
         feature_table = connector.join_feature_table_label_table(
             feature_table, label_table, trainer.entity_column, "inner"
         )
@@ -146,7 +142,6 @@ def preprocess_and_train(
     metrics_table: str,
     **kwargs,
 ):
-    session = kwargs.get("session", None)
     connector = kwargs.get("connector", None)
     trainer = kwargs.get("trainer", None)
     min_sample_for_training = constants.MIN_SAMPLES_FOR_TRAINING
@@ -162,7 +157,6 @@ def preprocess_and_train(
         feature_table_instance = prepare_feature_table(
             train_table_pair,
             input_column_types["timestamp"],
-            session=session,
             connector=connector,
             trainer=trainer,
         )
@@ -229,7 +223,6 @@ def preprocess_and_train(
             train_config,
             feature_table_column_types,
             metrics_table,
-            session=session,
             connector=connector,
             trainer=trainer,
         )
@@ -291,8 +284,7 @@ if __name__ == "__main__":
 
     warehouse = wh_creds["type"]
     train_procedure = train_and_store_model_results
-    connector = ConnectorFactory.create(warehouse, output_dir)
-    session = connector.build_session(wh_creds)
+    connector = ConnectorFactory.create(warehouse, wh_creds, output_dir)
     local_folder = connector.get_local_dir()
 
     material_info_ = args.material_names
@@ -308,7 +300,6 @@ if __name__ == "__main__":
         args.merged_config,
         args.input_column_types,
         args.metrics_table,
-        session=session,
         connector=connector,
         trainer=trainer,
     )

--- a/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
+++ b/src/predictions/rudderstack_predictions/ml_core/preprocess_and_train.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
 
     warehouse = wh_creds["type"]
     train_procedure = train_and_store_model_results
-    connector = ConnectorFactory.create(warehouse, wh_creds, output_dir)
+    connector = ConnectorFactory.create(wh_creds, output_dir)
     local_folder = connector.get_local_dir()
 
     material_info_ = args.material_names

--- a/src/predictions/rudderstack_predictions/predict.py
+++ b/src/predictions/rudderstack_predictions/predict.py
@@ -60,16 +60,15 @@ def _predict(
     )
 
     warehouse = creds["type"]
-    connector = ConnectorFactory.create(warehouse, folder_path)
-    session = connector.build_session(creds)
+    connector = ConnectorFactory.create(warehouse, creds, folder_path)
 
     connector.compute_udf_name(model_path)
-    connector.pre_job_cleanup(session)
+    connector.pre_job_cleanup()
 
     mode = connector.fetch_processor_mode(
         user_preference_order_infra, is_rudder_backend
     )
-    processor = ProcessorFactory.create(mode, trainer, connector, session, ml_core_path)
+    processor = ProcessorFactory.create(mode, trainer, connector, ml_core_path)
     logger.debug(f"Using {mode} processor for predictions")
 
     site_config = utils.load_yaml(site_config_path)

--- a/src/predictions/rudderstack_predictions/predict.py
+++ b/src/predictions/rudderstack_predictions/predict.py
@@ -58,9 +58,7 @@ def _predict(
     logger.debug(
         f"Started Predicting for {trainer.output_profiles_ml_model} to predict {trainer.label_column}"
     )
-
-    warehouse = creds["type"]
-    connector = ConnectorFactory.create(warehouse, creds, folder_path)
+    connector = ConnectorFactory.create(creds, folder_path)
 
     connector.compute_udf_name(model_path)
     connector.pre_job_cleanup()

--- a/src/predictions/rudderstack_predictions/processors/Processor.py
+++ b/src/predictions/rudderstack_predictions/processors/Processor.py
@@ -1,13 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import List, Union
+from typing import List
 
 from ..utils.constants import *
 from ..trainers.MLTrainer import MLTrainer
 from ..connectors.Connector import Connector
-
-import snowflake.snowpark
-import redshift_connector
-import redshift_connector.cursor
 
 
 class Processor(ABC):
@@ -15,12 +11,10 @@ class Processor(ABC):
         self,
         trainer: MLTrainer,
         connector: Connector,
-        session: Union[snowflake.snowpark.Session, redshift_connector.cursor.Cursor],
         ml_core_path: str,
     ):
         self.trainer = trainer
         self.connector = connector
-        self.session = session
         self.ml_core_path = ml_core_path
 
     @abstractmethod

--- a/src/predictions/rudderstack_predictions/processors/ProcessorFactory.py
+++ b/src/predictions/rudderstack_predictions/processors/ProcessorFactory.py
@@ -5,7 +5,7 @@ from ..utils import constants
 
 
 class ProcessorFactory:
-    def create(mode: str, trainer, connector, session, ml_core_path: str):
+    def create(mode: str, trainer, connector, ml_core_path: str):
         processor = None
         if mode == constants.RUDDERSTACK_MODE:
             # Lazy load K8sProcessor since kubernetes might not be installed in all environments
@@ -18,4 +18,4 @@ class ProcessorFactory:
             processor = LocalProcessor
         else:
             raise Exception(f"Invalid processor mode {mode}")
-        return processor(trainer, connector, session, ml_core_path)
+        return processor(trainer, connector, ml_core_path)

--- a/src/predictions/rudderstack_predictions/processors/SnowflakeProcessor.py
+++ b/src/predictions/rudderstack_predictions/processors/SnowflakeProcessor.py
@@ -23,7 +23,6 @@ class SnowflakeProcessor(Processor):
             model_config,
             input_column_types,
             metrics_table,
-            session=self.session,
             connector=self.connector,
             trainer=self.trainer,
         )
@@ -44,7 +43,6 @@ class SnowflakeProcessor(Processor):
             model_path,
             inputs,
             output_tablename,
-            session=self.session,
             connector=self.connector,
             trainer=self.trainer,
         )

--- a/src/predictions/rudderstack_predictions/train.py
+++ b/src/predictions/rudderstack_predictions/train.py
@@ -94,7 +94,7 @@ def _train(
         "user_preference_order_infra", None
     )
 
-    connector = ConnectorFactory.create(creds["type"], creds, folder_path)
+    connector = ConnectorFactory.create(creds, folder_path)
     whtService.init(connector, site_config_path, project_folder)
 
     (

--- a/src/predictions/rudderstack_predictions/train.py
+++ b/src/predictions/rudderstack_predictions/train.py
@@ -132,8 +132,8 @@ def _train(
 
         # FIXME: Avoid creating session multiple times
 
-        # This is to avoid the pickling error in snowpark
-        # TypeError: cannot pickle '_thread.lock' object
+        # This is to avoid the pickling error in snowpark - TypeError: cannot pickle '_thread.lock' object
+        # The implication of this is that the "self.session" is not available in Snowpark stored procedures
         connector.session.close()
         connector.session = None
         # A new session must be created before creating the stored procedure

--- a/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
+++ b/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
@@ -205,14 +205,14 @@ class MLTrainer(ABC):
         pass
 
     @abstractmethod
-    def prepare_label_table(self, connector: Connector, session, label_table_name: str):
+    def prepare_label_table(self, connector: Connector, label_table_name: str):
         pass
 
     @abstractmethod
     def plot_diagnostics(
         self,
         connector: Connector,
-        session,
+        session,  # session is being passed as argument since this function is called from Snowpark procedure
         model,
         stage_name: str,
         x: pd.DataFrame,
@@ -319,9 +319,7 @@ class MLTrainer(ABC):
         pass
 
     @abstractmethod
-    def check_min_data_requirement(
-        self, connector: Connector, session, materials
-    ) -> bool:
+    def check_min_data_requirement(self, connector: Connector, materials) -> bool:
         pass
 
     @abstractmethod
@@ -335,11 +333,8 @@ class MLTrainer(ABC):
         input_models: str,
         whtService: PythonWHT,
         connector: Connector,
-        session,
     ):
-        met_data_requirement = self.check_min_data_requirement(
-            connector, session, materials
-        )
+        met_data_requirement = self.check_min_data_requirement(connector, materials)
 
         logger.debug(f"Min data requirement satisfied: {met_data_requirement}")
         logger.debug(
@@ -418,11 +413,11 @@ class MLTrainer(ABC):
             logger.debug(f"new label tables: {[m.label_table_name for m in materials]}")
             if (
                 self.materialisation_strategy == "auto"
-                and self.check_min_data_requirement(connector, session, materials)
+                and self.check_min_data_requirement(connector, materials)
             ):
                 logger.info("Minimum data requirement satisfied.")
                 break
-        if not self.check_min_data_requirement(connector, session, materials):
+        if not self.check_min_data_requirement(connector, materials):
             logger.warning(
                 "Minimum data requirement not satisfied. Model performance may suffer. Try adding more datapoints by including more dates or increasing max_no_of_dates in the config."
             )
@@ -442,13 +437,10 @@ class ClassificationTrainer(MLTrainer):
         for model in [XGBClassifier, RandomForestClassifier]
     }
 
-    def __init__(
-        self, connector: Connector, session, entity_var_model_name: str, **kwargs
-    ):
+    def __init__(self, connector: Connector, entity_var_model_name: str, **kwargs):
         super().__init__(**kwargs)
         if self.label_value is None:
             self.label_value = connector.get_default_label_value(
-                session,
                 entity_var_model_name,
                 self.label_column,
                 constants.POSITIVE_BOOLEAN_FLAGS,
@@ -525,9 +517,8 @@ class ClassificationTrainer(MLTrainer):
 
         return final_clf
 
-    def prepare_label_table(self, connector: Connector, session, label_table_name: str):
+    def prepare_label_table(self, connector: Connector, label_table_name: str):
         label_table = connector.label_table(
-            session,
             label_table_name,
             self.label_column,
             self.entity_column,
@@ -610,12 +601,9 @@ class ClassificationTrainer(MLTrainer):
             feature_table, self.label_column
         ) and connector.validate_class_proportions(feature_table, self.label_column)
 
-    def check_min_data_requirement(
-        self, connector: Connector, session, materials
-    ) -> bool:
+    def check_min_data_requirement(self, connector: Connector, materials) -> bool:
         label_column = self.label_column
         return connector.check_for_classification_data_requirement(
-            session,
             materials,
             label_column,
             self.label_value,
@@ -714,9 +702,8 @@ class RegressionTrainer(MLTrainer):
 
         return final_reg
 
-    def prepare_label_table(self, connector: Connector, session, label_table_name: str):
+    def prepare_label_table(self, connector: Connector, label_table_name: str):
         return connector.label_table(
-            session,
             label_table_name,
             self.label_column,
             self.entity_column,
@@ -783,10 +770,10 @@ class RegressionTrainer(MLTrainer):
         ) and connector.validate_label_distinct_values(feature_table, self.label_column)
 
     def check_min_data_requirement(
-        self, connector: Connector, session, materials
+        self, connector: Connector, materials
     ) -> bool:
         return connector.check_for_regression_data_requirement(
-            session, materials, self.eligible_users
+            materials, self.eligible_users
         )
 
     def predict(self, trained_model, df) -> Any:

--- a/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
+++ b/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
@@ -212,7 +212,8 @@ class MLTrainer(ABC):
     def plot_diagnostics(
         self,
         connector: Connector,
-        session,  # session is being passed as argument since this function is called from Snowpark procedure
+        # session is being passed as argument since "self.session" is not available in Snowpark stored procedure
+        session,
         model,
         stage_name: str,
         x: pd.DataFrame,

--- a/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
+++ b/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
@@ -770,9 +770,7 @@ class RegressionTrainer(MLTrainer):
             feature_table, self.label_column
         ) and connector.validate_label_distinct_values(feature_table, self.label_column)
 
-    def check_min_data_requirement(
-        self, connector: Connector, materials
-    ) -> bool:
+    def check_min_data_requirement(self, connector: Connector, materials) -> bool:
         return connector.check_for_regression_data_requirement(
             materials, self.eligible_users
         )

--- a/src/predictions/rudderstack_predictions/trainers/TrainerFactory.py
+++ b/src/predictions/rudderstack_predictions/trainers/TrainerFactory.py
@@ -6,13 +6,12 @@ class TrainerFactory:
     def create(
         model_config,
         connector: Connector = None,
-        session=None,
         entity_var_model_name: str = None,
     ) -> MLTrainer:
         task = model_config["data"].get("task", "classification")
         if task == "classification":
             return ClassificationTrainer(
-                connector, session, entity_var_model_name, **model_config
+                connector, entity_var_model_name, **model_config
             )
         elif task == "regression":
             return RegressionTrainer(**model_config)

--- a/src/predictions/rudderstack_predictions/utils/utils.py
+++ b/src/predictions/rudderstack_predictions/utils/utils.py
@@ -828,8 +828,7 @@ def get_timestamp_columns(table: snowflake.snowpark.Table) -> List[str]:
     return timestamp_columns
 
 
-# Not being called currently. Functions for saving feature-importance score for top_k and
-# bottom_k users as per their prediction scores. ####
+# TODO: Remove this unused code
 def explain_prediction(
     creds: dict,
     user_main_id: str,

--- a/src/predictions/rudderstack_predictions/wht/mockPB.py
+++ b/src/predictions/rudderstack_predictions/wht/mockPB.py
@@ -5,7 +5,13 @@ class MockPB:
     def get_latest_material_hash(self, *args):
         # SELECT * FROM MATERIAL_REGISTRY_4 WHERE model_type='entity_var_model'
         # AND end_ts BETWEEN CURRENT_DATE - INTERVAL '14 days' AND CURRENT_DATE - INTERVAL '7 days';
-        return "8b944948", "user_var_table"
+        return "bd659b57", "user_var_table"
 
     def run(self, *args):
         return RudderPB().run(*args)
+
+    def show_models(self, arg: dict):
+        return RudderPB().show_models(arg)
+
+    def extract_json_from_stdout(self, stdout):
+        return RudderPB().extract_json_from_stdout(stdout)

--- a/src/predictions/rudderstack_predictions/wht/pyNativeWHT.py
+++ b/src/predictions/rudderstack_predictions/wht/pyNativeWHT.py
@@ -14,11 +14,10 @@ class PyNativeWHT:
     def init(
         self,
         connector: Connector,
-        session,
         site_config_path: str,
         project_folder_path: str,
     ) -> None:
-        self.pythonWHT.init(connector, session, site_config_path, project_folder_path)
+        self.pythonWHT.init(connector, site_config_path, project_folder_path)
 
     def get_latest_entity_var_table(self, entity_key: str) -> Tuple[str, str, str]:
         model_ref = f"entity/{entity_key}/var_table"

--- a/src/predictions/rudderstack_predictions/wht/pythonWHT.py
+++ b/src/predictions/rudderstack_predictions/wht/pythonWHT.py
@@ -24,12 +24,10 @@ class PythonWHT:
     def init(
         self,
         connector: Connector,
-        session,
         site_config_path: str,
         project_folder_path: str,
     ) -> None:
         self.connector = connector
-        self.session = session
         self.site_config_path = site_config_path
         self.project_folder_path = project_folder_path
         self.cached_registry_table_name = ""
@@ -82,7 +80,7 @@ class PythonWHT:
     def get_registry_table_name(self):
         if self.cached_registry_table_name == "":
             material_registry_tables = self.connector.get_tables_by_prefix(
-                self.session, "MATERIAL_REGISTRY"
+                "MATERIAL_REGISTRY"
             )
 
             sorted_material_registry_tables = sorted(
@@ -102,7 +100,6 @@ class PythonWHT:
 
     def get_model_creation_ts(self, model_hash: str, entity_key: str):
         return self.connector.get_creation_ts(
-            self.session,
             self.get_registry_table_name(),
             model_hash,
             entity_key,
@@ -134,7 +131,6 @@ class PythonWHT:
                     material_table_query, int(feature_material_seq_no)
                 )
                 assert self.connector.check_table_entry_in_material_registry(
-                    self.session,
                     self.get_registry_table_name(),
                     self.split_material_name(feature_table_query),
                 ), f"Material table {feature_table_query} does not exist"
@@ -144,7 +140,6 @@ class PythonWHT:
                     material_table_query, int(label_material_seq_no)
                 )
                 assert self.connector.check_table_entry_in_material_registry(
-                    self.session,
                     self.get_registry_table_name(),
                     self.split_material_name(label_table_query),
                 ), f"Material table {label_table_query} does not exist"
@@ -176,10 +171,10 @@ class PythonWHT:
 
         if (
             feature_material_name is not None
-            and not self.connector.is_valid_table(self.session, feature_material_name)
+            and not self.connector.is_valid_table(feature_material_name)
         ) or (
             label_material_name is not None
-            and not self.connector.is_valid_table(self.session, label_material_name)
+            and not self.connector.is_valid_table(label_material_name)
         ):
             return
 
@@ -232,7 +227,6 @@ class PythonWHT:
             each containing the names of the feature and label tables, as well as their corresponding training dates.
         """
         feature_label_df = self.connector.join_feature_label_tables(
-            self.session,
             self.get_registry_table_name(),
             entity_var_model_name,
             model_hash,
@@ -310,8 +304,7 @@ class PythonWHT:
             ):
                 feature_table_name_ = material_info.feature_table_name
                 assert (
-                    self.connector.is_valid_table(self.session, feature_table_name_)
-                    is True
+                    self.connector.is_valid_table(feature_table_name_) is True
                 ), f"Failed to fetch \
                     valid feature_date and label_date because table {feature_table_name_} does not exist in the warehouse"
                 label_date = utils.date_add(
@@ -324,8 +317,7 @@ class PythonWHT:
             ):
                 label_table_name_ = material_info.label_table_name
                 assert (
-                    self.connector.is_valid_table(self.session, label_table_name_)
-                    is True
+                    self.connector.is_valid_table(label_table_name_) is True
                 ), f"Failed to fetch \
                     valid feature_date and label_date because table {label_table_name_} does not exist in the warehouse"
                 feature_date = utils.date_add(

--- a/tests/integration/bigquery/classifier.py
+++ b/tests/integration/bigquery/classifier.py
@@ -141,7 +141,7 @@ def test_classification():
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
     input_model_hash, latest_seq_no = get_latest_entity_var(
-        creds, siteconfig_path, project_path
+        creds, siteconfig_path, project_path, train_input_model_name
     )
 
     train_inputs = [

--- a/tests/integration/bigquery/classifier.py
+++ b/tests/integration/bigquery/classifier.py
@@ -32,7 +32,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": "1=1",
-    "label_column": label_column,
+    "label_column": classifier_label_column,
     "task": "classification",
     "output_profiles_ml_model": output_model_name,
     "train_start_dt": "2024-03-06",

--- a/tests/integration/bigquery/classifier.py
+++ b/tests/integration/bigquery/classifier.py
@@ -4,11 +4,6 @@ from train import *
 import shutil
 from predict import *
 import time
-from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
-from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
-    ConnectorFactory,
-)
-
 import json
 
 
@@ -133,9 +128,6 @@ def validate_reports():
 
 
 def test_classification():
-    connector = ConnectorFactory.create("bigquery", folder_path_output_file)
-    session = connector.build_session(creds)
-
     st = time.time()
 
     create_site_config_file(creds, siteconfig_path)

--- a/tests/integration/bigquery/classifier.py
+++ b/tests/integration/bigquery/classifier.py
@@ -25,7 +25,6 @@ folder_path_output_file = os.path.dirname(output_filename)
 os.makedirs(output_folder, exist_ok=True)
 
 train_input_model_name = "predictions_dev_features"
-material_registry_table_name = "MATERIAL_REGISTRY_4"
 
 data = {
     "prediction_horizon_days": pred_horizon_days,

--- a/tests/integration/bigquery/classifier.py
+++ b/tests/integration/bigquery/classifier.py
@@ -148,22 +148,9 @@ def test_classification():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
-        entity_key,
-        siteconfig_path,
-        project_path,
+    input_model_hash, latest_seq_no = get_latest_entity_var(
+        creds, siteconfig_path, project_path
     )
-
-    latest_seq_no = connector.get_latest_seq_no_from_registry(
-        session, material_registry_table_name, latest_model_hash, entity_var_model_name
-    )
-
-    input_model_hash = connector.get_model_hash_from_registry(
-        session, material_registry_table_name, train_input_model_name, latest_seq_no
-    )
-
-    # Closing the session immediately after use to avoid multiple open sessions conflict
-    session.close()
 
     train_inputs = [
         f"""SELECT * FROM {creds['project_id']}.{creds['schema']}.material_{train_input_model_name}_{input_model_hash}_{latest_seq_no}""",

--- a/tests/integration/bigquery/classifier.py
+++ b/tests/integration/bigquery/classifier.py
@@ -32,7 +32,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": "1=1",
-    "label_column": classifier_label_column,
+    "label_column": "total_sessions_till_date",
     "task": "classification",
     "output_profiles_ml_model": output_model_name,
     "train_start_dt": "2024-03-06",

--- a/tests/integration/bigquery/regressor.py
+++ b/tests/integration/bigquery/regressor.py
@@ -22,7 +22,6 @@ folder_path_output_file = os.path.dirname(output_filename)
 os.makedirs(output_folder, exist_ok=True)
 
 train_input_model_name = "predictions_dev_features"
-material_registry_table_name = "MATERIAL_REGISTRY_4"
 
 data = {
     "prediction_horizon_days": pred_horizon_days,

--- a/tests/integration/bigquery/regressor.py
+++ b/tests/integration/bigquery/regressor.py
@@ -136,22 +136,9 @@ def test_regressor():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
-        entity_key,
-        siteconfig_path,
-        project_path,
+    input_model_hash, latest_seq_no = get_latest_entity_var(
+        creds, siteconfig_path, project_path
     )
-
-    latest_seq_no = connector.get_latest_seq_no_from_registry(
-        session, material_registry_table_name, latest_model_hash, entity_var_model_name
-    )
-
-    input_model_hash = connector.get_model_hash_from_registry(
-        session, material_registry_table_name, train_input_model_name, latest_seq_no
-    )
-
-    # Closing the session immediately after use to avoid multiple open sessions conflict
-    session.close()
 
     train_inputs = [
         f"""SELECT * FROM {creds['project_id']}.{creds['schema']}.material_{train_input_model_name}_{input_model_hash}_{latest_seq_no}""",

--- a/tests/integration/bigquery/regressor.py
+++ b/tests/integration/bigquery/regressor.py
@@ -116,9 +116,6 @@ def validate_reports_regression():
 
 
 def test_regressor():
-    connector = ConnectorFactory.create("bigquery", folder_path_output_file)
-    session = connector.build_session(creds)
-
     current_dir = os.path.dirname(os.path.abspath(__file__))
     project_path = os.path.join(current_dir, "sample_project")
     siteconfig_path = os.path.join(project_path, "siteconfig.yaml")

--- a/tests/integration/bigquery/regressor.py
+++ b/tests/integration/bigquery/regressor.py
@@ -2,13 +2,12 @@ import os
 from train import *
 import shutil
 from predict import *
-
 from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
 from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
     ConnectorFactory,
 )
 import json
-from tests.integration.utils import create_site_config_file
+from tests.integration.utils import *
 
 creds = json.loads(os.environ["BIGQUERY_SITE_CONFIG"])
 creds["schema"] = "PROFILES_INTEGRATION_TEST"
@@ -22,19 +21,7 @@ folder_path_output_file = os.path.dirname(output_filename)
 
 os.makedirs(output_folder, exist_ok=True)
 
-package_name = "feature_table"
-feature_table_name = "predictions_dev_features"
-eligible_users = "days_since_last_seen IS NOT NULL"
-package_name = "feature_table"
-label_column = "days_since_last_seen"
-inputs = [f"packages/{package_name}/models/{feature_table_name}"]
 train_input_model_name = "predictions_dev_features"
-output_model_name = "days_last_seen_regression_integration_test"
-pred_horizon_days = 7
-pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
-s3_config = {}
-p_output_tablename = "test_run_can_delete_0"
-entity_key = "user"
 material_registry_table_name = "MATERIAL_REGISTRY_4"
 
 data = {
@@ -129,36 +116,6 @@ def validate_reports_regression():
         raise Exception(f"{missing_files} not found in reports directory")
 
 
-def validate_predictions_df():
-    connector = ConnectorFactory.create("bigquery", folder_path_output_file)
-    session = connector.build_session(creds)
-
-    required_columns = [
-        "USER_MAIN_ID",
-        "VALID_AT",
-        pred_column,
-        "MODEL_ID",
-        f"PERCENTILE_{pred_column}",
-    ]
-
-    required_columns_lower = [column.lower() for column in required_columns]
-
-    try:
-        df = connector.get_table_as_dataframe(session, p_output_tablename)
-        columns_in_file = df.columns.tolist()
-        print(columns_in_file)
-    except Exception as e:
-        raise e
-
-    # Check if the required columns are present
-    if not set(required_columns_lower).issubset(columns_in_file):
-        missing_columns = set(required_columns_lower) - set(columns_in_file)
-        raise Exception(f"Miissing columns: {missing_columns} in predictions table.")
-
-    session.close()
-    return True
-
-
 def test_regressor():
     connector = ConnectorFactory.create("bigquery", folder_path_output_file)
     session = connector.build_session(creds)
@@ -232,7 +189,7 @@ def test_regressor():
             predict_config,
             runtime_info,
         )
-        validate_predictions_df()
+        validate_predictions_df_regressor(creds)
 
     except Exception as e:
         raise e

--- a/tests/integration/bigquery/regressor.py
+++ b/tests/integration/bigquery/regressor.py
@@ -29,7 +29,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": eligible_users,
-    "label_column": label_column,
+    "label_column": regressor_label_column,
     "task": "regression",
     "output_profiles_ml_model": output_model_name,
     "train_start_dt": "2024-03-06",

--- a/tests/integration/bigquery/regressor.py
+++ b/tests/integration/bigquery/regressor.py
@@ -137,7 +137,7 @@ def test_regressor():
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
     input_model_hash, latest_seq_no = get_latest_entity_var(
-        creds, siteconfig_path, project_path
+        creds, siteconfig_path, project_path, train_input_model_name
     )
 
     train_inputs = [

--- a/tests/integration/redshift/classifier.py
+++ b/tests/integration/redshift/classifier.py
@@ -19,6 +19,8 @@ folder_path_output_file = os.path.dirname(output_filename)
 
 os.makedirs(output_folder, exist_ok=True)
 
+train_input_model_name = "shopify_user_features"
+
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -164,7 +166,7 @@ def test_classification():
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
     input_model_hash, latest_seq_no = get_latest_entity_var(
-        creds, siteconfig_path, project_path
+        creds, siteconfig_path, project_path, train_input_model_name
     )
 
     train_inputs = [

--- a/tests/integration/redshift/classifier.py
+++ b/tests/integration/redshift/classifier.py
@@ -19,8 +19,6 @@ folder_path_output_file = os.path.dirname(output_filename)
 
 os.makedirs(output_folder, exist_ok=True)
 
-train_input_model_name = "shopify_user_features"
-
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -165,7 +163,7 @@ def test_classification():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+    input_model_hash, latest_seq_no = get_latest_entity_var(
         creds, siteconfig_path, project_path
     )
 

--- a/tests/integration/redshift/classifier.py
+++ b/tests/integration/redshift/classifier.py
@@ -226,7 +226,7 @@ def test_classification():
     )
 
     latest_seq_no = connector.get_latest_seq_no_from_registry(
-        session, material_registry_table_name, latest_model_hash, entity_var_model_name
+        material_registry_table_name, latest_model_hash, entity_var_model_name
     )
 
     input_model_hash = connector.get_model_hash_from_registry(

--- a/tests/integration/redshift/classifier.py
+++ b/tests/integration/redshift/classifier.py
@@ -26,7 +26,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": "1=1",
-    "label_column": label_column,
+    "label_column": classifier_label_column,
     "task": "classification",
     "output_profiles_ml_model": output_model_name,
 }

--- a/tests/integration/redshift/regressor.py
+++ b/tests/integration/redshift/regressor.py
@@ -28,7 +28,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": eligible_users,
-    "label_column": label_column,
+    "label_column": regressor_label_column,
     "task": "regression",
     "output_profiles_ml_model": output_model_name,
 }

--- a/tests/integration/redshift/regressor.py
+++ b/tests/integration/redshift/regressor.py
@@ -4,9 +4,8 @@ from predict import *
 from src.predictions.rudderstack_predictions.connectors.RedshiftConnector import (
     RedshiftConnector,
 )
-from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
 import json
-from tests.integration.utils import create_site_config_file
+from tests.integration.utils import *
 import os
 
 creds = json.loads(os.environ["REDSHIFT_SITE_CONFIG"])
@@ -22,21 +21,7 @@ folder_path_output_file = os.path.dirname(output_filename)
 
 os.makedirs(output_folder, exist_ok=True)
 
-package_name = "feature_table"
-feature_table_name = "shopify_user_features"
-eligible_users = "days_since_last_seen IS NOT NULL"
-package_name = "feature_table"
-label_column = "days_since_last_seen"
-inputs = [f"packages/{package_name}/models/{feature_table_name}"]
 train_input_model_name = "shopify_user_features"
-output_model_name = "ltv_regression_integration_test"
-pred_horizon_days = 7
-pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
-s3_config = {}
-p_output_tablename = "test_run_can_delete_2"
-entity_key = "user"
-material_registry_table_name = "material_registry_4"
-
 
 data = {
     "prediction_horizon_days": pred_horizon_days,
@@ -155,40 +140,7 @@ def validate_reports_regression():
         raise Exception(f"{missing_files} not found in reports directory")
 
 
-def validate_predictions_df():
-    connector = RedshiftConnector(folder_path_output_file)
-    session = connector.build_session(creds)
-
-    required_columns = [
-        "USER_MAIN_ID",
-        "VALID_AT",
-        pred_column,
-        "MODEL_ID",
-        f"PERCENTILE_{pred_column}",
-    ]
-
-    required_columns_lower = [column.lower() for column in required_columns]
-
-    try:
-        df = connector.get_table_as_dataframe(session, p_output_tablename)
-        columns_in_file = df.columns.tolist()
-        print(columns_in_file)
-    except Exception as e:
-        raise e
-
-    # Check if the required columns are present
-    if not set(required_columns_lower).issubset(columns_in_file):
-        missing_columns = set(required_columns_lower) - set(columns_in_file)
-        raise Exception(f"Miissing columns: {missing_columns} in predictions table.")
-
-    session.close()
-    return True
-
-
 def test_regressor():
-    connector = RedshiftConnector(folder_path_output_file)
-    session = connector.build_session(creds)
-
     current_dir = os.path.dirname(os.path.abspath(__file__))
     project_path = os.path.join(current_dir, "sample_project")
     siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
@@ -206,22 +158,9 @@ def test_regressor():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
-        entity_key,
-        siteconfig_path,
-        project_path,
+    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+        creds, siteconfig_path, project_path
     )
-
-    latest_seq_no = connector.get_latest_seq_no_from_registry(
-        material_registry_table_name, latest_model_hash, entity_var_model_name
-    )
-
-    input_model_hash = connector.get_model_hash_from_registry(
-        session, material_registry_table_name, train_input_model_name, latest_seq_no
-    )
-
-    # Closing the session immediately after use to avoid multiple open sessions conflict
-    session.close()
 
     train_inputs = [
         f"""SELECT * FROM {creds['schema']}.material_{train_input_model_name}_{input_model_hash}_{latest_seq_no}""",
@@ -258,7 +197,7 @@ def test_regressor():
             predict_config,
             runtime_info,
         )
-        validate_predictions_df()
+        validate_predictions_df_regressor(creds)
 
     except Exception as e:
         raise e

--- a/tests/integration/redshift/regressor.py
+++ b/tests/integration/redshift/regressor.py
@@ -21,6 +21,8 @@ folder_path_output_file = os.path.dirname(output_filename)
 
 os.makedirs(output_folder, exist_ok=True)
 
+train_input_model_name = "shopify_user_features"
+
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -157,7 +159,7 @@ def test_regressor():
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
     input_model_hash, latest_seq_no = get_latest_entity_var(
-        creds, siteconfig_path, project_path
+        creds, siteconfig_path, project_path, train_input_model_name
     )
 
     train_inputs = [

--- a/tests/integration/redshift/regressor.py
+++ b/tests/integration/redshift/regressor.py
@@ -213,7 +213,7 @@ def test_regressor():
     )
 
     latest_seq_no = connector.get_latest_seq_no_from_registry(
-        session, material_registry_table_name, latest_model_hash, entity_var_model_name
+        material_registry_table_name, latest_model_hash, entity_var_model_name
     )
 
     input_model_hash = connector.get_model_hash_from_registry(

--- a/tests/integration/redshift/regressor.py
+++ b/tests/integration/redshift/regressor.py
@@ -21,8 +21,6 @@ folder_path_output_file = os.path.dirname(output_filename)
 
 os.makedirs(output_folder, exist_ok=True)
 
-train_input_model_name = "shopify_user_features"
-
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -158,7 +156,7 @@ def test_regressor():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+    input_model_hash, latest_seq_no = get_latest_entity_var(
         creds, siteconfig_path, project_path
     )
 

--- a/tests/integration/snowflake/classifier.py
+++ b/tests/integration/snowflake/classifier.py
@@ -22,7 +22,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": "1=1",
-    "label_column": label_column,
+    "label_column": classifier_label_column,
     "task": "classification",
     "output_profiles_ml_model": output_model_name,
     "train_start_dt": "2024-02-08",

--- a/tests/integration/snowflake/classifier.py
+++ b/tests/integration/snowflake/classifier.py
@@ -2,12 +2,8 @@ from train import *
 import shutil
 import time
 from predict import *
-from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
-from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
-    ConnectorFactory,
-)
 import json
-from tests.integration.utils import create_site_config_file
+from tests.integration.utils import *
 import os
 
 creds = json.loads(os.environ["SNOWFLAKE_SITE_CONFIG"])
@@ -19,22 +15,7 @@ siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
 output_filename = os.path.join(current_dir, "output/output.json")
 output_folder = os.path.join(current_dir, "output")
 
-package_name = "feature_table"
-feature_table_name = "shopify_user_features"
-eligible_users = "1=1"
-package_name = "feature_table"
-label_column = "is_churned_7_days"
-inputs = [f"packages/{package_name}/models/{feature_table_name}"]
 train_input_model_name = "shopify_user_features"
-output_model_name = "ltv_classification_integration_test"
-pred_horizon_days = 7
-pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
-output_label = "OUTPUT_LABEL"
-s3_config = {}
-p_output_tablename = "test_run_can_delete_2"
-entity_key = "user"
-material_registry_table_name = "MATERIAL_REGISTRY_4"
-
 
 data = {
     "prediction_horizon_days": pred_horizon_days,
@@ -172,36 +153,7 @@ def validate_reports():
         raise Exception(f"{missing_files} not found in reports directory")
 
 
-def validate_predictions_df():
-    connector = ConnectorFactory.create("snowflake", creds)
-    session = connector.build_session(creds)
-    required_columns = [
-        "USER_MAIN_ID",
-        "VALID_AT",
-        pred_column,
-        "MODEL_ID",
-        output_label,
-        f"PERCENTILE_{pred_column}",
-    ]
-
-    try:
-        df = connector.get_table_as_dataframe(session, p_output_tablename)
-        columns_in_file = df.columns.tolist()
-    except Exception as e:
-        raise e
-
-    # Check if the required columns are present
-    if not set(required_columns).issubset(columns_in_file):
-        missing_columns = set(required_columns) - set(columns_in_file)
-        raise Exception(f"Miissing columns: {missing_columns} in predictions csv file.")
-
-    session.close()
-    return True
-
-
 def test_classification():
-    connector = ConnectorFactory.create("snowflake", creds)
-
     st = time.time()
 
     create_site_config_file(creds, siteconfig_path)
@@ -214,24 +166,9 @@ def test_classification():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
-        entity_key,
-        siteconfig_path,
-        project_path,
+    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+        creds, siteconfig_path, project_path
     )
-
-    latest_seq_no = connector.get_latest_seq_no_from_registry(
-        material_registry_table_name,
-        latest_model_hash,
-        entity_var_model_name,
-    )
-
-    input_model_hash = connector.get_model_hash_from_registry(
-        session, material_registry_table_name, train_input_model_name, latest_seq_no
-    )
-
-    # Closing the session immediately after use to avoid multiple open sessions conflict
-    connector.session.close()
 
     train_inputs = [
         f"""SELECT * FROM {creds['schema']}.material_{train_input_model_name}_{input_model_hash}_{latest_seq_no}""",
@@ -269,7 +206,7 @@ def test_classification():
             predict_config,
             runtime_info,
         )
-        validate_predictions_df()
+        validate_predictions_df_classification()
 
     except Exception as e:
         raise e

--- a/tests/integration/snowflake/classifier.py
+++ b/tests/integration/snowflake/classifier.py
@@ -15,8 +15,6 @@ siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
 output_filename = os.path.join(current_dir, "output/output.json")
 output_folder = os.path.join(current_dir, "output")
 
-train_input_model_name = "shopify_user_features"
-
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -166,7 +164,7 @@ def test_classification():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+    input_model_hash, latest_seq_no = get_latest_entity_var(
         creds, siteconfig_path, project_path
     )
 

--- a/tests/integration/snowflake/classifier.py
+++ b/tests/integration/snowflake/classifier.py
@@ -206,7 +206,7 @@ def test_classification():
             predict_config,
             runtime_info,
         )
-        validate_predictions_df_classification()
+        validate_predictions_df_classification(creds)
 
     except Exception as e:
         raise e

--- a/tests/integration/snowflake/classifier.py
+++ b/tests/integration/snowflake/classifier.py
@@ -15,6 +15,8 @@ siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
 output_filename = os.path.join(current_dir, "output/output.json")
 output_folder = os.path.join(current_dir, "output")
 
+train_input_model_name = "shopify_user_features"
+
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -165,7 +167,7 @@ def test_classification():
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
     input_model_hash, latest_seq_no = get_latest_entity_var(
-        creds, siteconfig_path, project_path
+        creds, siteconfig_path, project_path, train_input_model_name
     )
 
     train_inputs = [

--- a/tests/integration/snowflake/classifier.py
+++ b/tests/integration/snowflake/classifier.py
@@ -173,7 +173,7 @@ def validate_reports():
 
 
 def validate_predictions_df():
-    connector = ConnectorFactory.create("snowflake")
+    connector = ConnectorFactory.create("snowflake", creds)
     session = connector.build_session(creds)
     required_columns = [
         "USER_MAIN_ID",
@@ -200,8 +200,7 @@ def validate_predictions_df():
 
 
 def test_classification():
-    connector = ConnectorFactory.create("snowflake")
-    session = connector.build_session(creds)
+    connector = ConnectorFactory.create("snowflake", creds)
 
     st = time.time()
 
@@ -222,7 +221,9 @@ def test_classification():
     )
 
     latest_seq_no = connector.get_latest_seq_no_from_registry(
-        session, material_registry_table_name, latest_model_hash, entity_var_model_name
+        material_registry_table_name,
+        latest_model_hash,
+        entity_var_model_name,
     )
 
     input_model_hash = connector.get_model_hash_from_registry(
@@ -230,7 +231,7 @@ def test_classification():
     )
 
     # Closing the session immediately after use to avoid multiple open sessions conflict
-    session.close()
+    connector.session.close()
 
     train_inputs = [
         f"""SELECT * FROM {creds['schema']}.material_{train_input_model_name}_{input_model_hash}_{latest_seq_no}""",

--- a/tests/integration/snowflake/regressor.py
+++ b/tests/integration/snowflake/regressor.py
@@ -155,7 +155,7 @@ def validate_reports_regression():
 
 
 def validate_predictions_df():
-    connector = ConnectorFactory.create("snowflake")
+    connector = ConnectorFactory.create("snowflake", creds)
     session = connector.build_session(creds)
     required_columns = [
         "USER_MAIN_ID",
@@ -181,7 +181,7 @@ def validate_predictions_df():
 
 
 def test_regressor():
-    connector = ConnectorFactory.create("snowflake")
+    connector = ConnectorFactory.create("snowflake", creds)
     session = connector.build_session(creds)
 
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -208,7 +208,7 @@ def test_regressor():
     )
 
     latest_seq_no = connector.get_latest_seq_no_from_registry(
-        session, material_registry_table_name, latest_model_hash, entity_var_model_name
+        material_registry_table_name, latest_model_hash, entity_var_model_name
     )
 
     input_model_hash = connector.get_model_hash_from_registry(

--- a/tests/integration/snowflake/regressor.py
+++ b/tests/integration/snowflake/regressor.py
@@ -15,6 +15,8 @@ siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
 output_filename = os.path.join(current_dir, "output/output.json")
 output_folder = os.path.join(current_dir, "output")
 
+train_input_model_name = "shopify_user_features"
+
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -153,7 +155,7 @@ def test_regressor():
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
     input_model_hash, latest_seq_no = get_latest_entity_var(
-        creds, siteconfig_path, project_path
+        creds, siteconfig_path, project_path, train_input_model_name
     )
 
     train_inputs = [

--- a/tests/integration/snowflake/regressor.py
+++ b/tests/integration/snowflake/regressor.py
@@ -15,8 +15,6 @@ siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
 output_filename = os.path.join(current_dir, "output/output.json")
 output_folder = os.path.join(current_dir, "output")
 
-train_input_model_name = "shopify_user_features"
-
 data = {
     "prediction_horizon_days": pred_horizon_days,
     "features_profiles_model": feature_table_name,
@@ -154,7 +152,7 @@ def test_regressor():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+    input_model_hash, latest_seq_no = get_latest_entity_var(
         creds, siteconfig_path, project_path
     )
 

--- a/tests/integration/snowflake/regressor.py
+++ b/tests/integration/snowflake/regressor.py
@@ -1,12 +1,8 @@
 from train import *
 import shutil
 from predict import *
-from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
-from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
-    ConnectorFactory,
-)
 import json
-from tests.integration.utils import create_site_config_file
+from tests.integration.utils import *
 import os
 
 creds = json.loads(os.environ["SNOWFLAKE_SITE_CONFIG"])
@@ -19,21 +15,7 @@ siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
 output_filename = os.path.join(current_dir, "output/output.json")
 output_folder = os.path.join(current_dir, "output")
 
-package_name = "feature_table"
-feature_table_name = "shopify_user_features"
-eligible_users = "1=1"
-package_name = "feature_table"
-label_column = "days_since_last_seen"
-inputs = [f"packages/{package_name}/models/{feature_table_name}"]
 train_input_model_name = "shopify_user_features"
-output_model_name = "ltv_regression_integration_test"
-pred_horizon_days = 7
-pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
-s3_config = {}
-p_output_tablename = "test_run_can_delete_2"
-entity_key = "user"
-material_registry_table_name = "MATERIAL_REGISTRY_4"
-
 
 data = {
     "prediction_horizon_days": pred_horizon_days,
@@ -154,36 +136,7 @@ def validate_reports_regression():
         raise Exception(f"{missing_files} not found in reports directory")
 
 
-def validate_predictions_df():
-    connector = ConnectorFactory.create("snowflake", creds)
-    session = connector.build_session(creds)
-    required_columns = [
-        "USER_MAIN_ID",
-        "VALID_AT",
-        pred_column,
-        "MODEL_ID",
-        f"PERCENTILE_{pred_column}",
-    ]
-
-    try:
-        df = connector.get_table_as_dataframe(session, p_output_tablename)
-        columns_in_file = df.columns.tolist()
-    except Exception as e:
-        raise e
-
-    # Check if the required columns are present
-    if not set(required_columns).issubset(columns_in_file):
-        missing_columns = set(required_columns) - set(columns_in_file)
-        raise Exception(f"Miissing columns: {missing_columns} in predictions csv file.")
-
-    session.close()
-    return True
-
-
 def test_regressor():
-    connector = ConnectorFactory.create("snowflake", creds)
-    session = connector.build_session(creds)
-
     current_dir = os.path.dirname(os.path.abspath(__file__))
     project_path = os.path.join(current_dir, "sample_project")
     siteconfig_path = os.path.join(project_path, "siteconfig.yaml")
@@ -201,22 +154,9 @@ def test_regressor():
     ]
     reports_folders = [folder for folder in folders if folder.endswith("_reports")]
 
-    latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
-        entity_key,
-        siteconfig_path,
-        project_path,
+    entity_var_model_name, latest_model_hash, latest_seq_no = get_latest_entity_var(
+        creds, siteconfig_path, project_path
     )
-
-    latest_seq_no = connector.get_latest_seq_no_from_registry(
-        material_registry_table_name, latest_model_hash, entity_var_model_name
-    )
-
-    input_model_hash = connector.get_model_hash_from_registry(
-        session, material_registry_table_name, train_input_model_name, latest_seq_no
-    )
-
-    # Closing the session immediately after use to avoid multiple open sessions conflict
-    session.close()
 
     train_inputs = [
         f"""SELECT * FROM {creds['schema']}.material_{train_input_model_name}_{input_model_hash}_{latest_seq_no}""",
@@ -253,7 +193,7 @@ def test_regressor():
             predict_config,
             runtime_info,
         )
-        validate_predictions_df()
+        validate_predictions_df_regressor(creds)
 
     except Exception as e:
         raise e

--- a/tests/integration/snowflake/regressor.py
+++ b/tests/integration/snowflake/regressor.py
@@ -22,7 +22,7 @@ data = {
     "features_profiles_model": feature_table_name,
     "inputs": inputs,
     "eligible_users": "1=1",
-    "label_column": label_column,
+    "label_column": regressor_label_column,
     "task": "regression",
     "output_profiles_ml_model": output_model_name,
     "train_start_dt": "2024-02-08",

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -34,7 +34,9 @@ def create_site_config_file(creds, siteconfig_path):
         file.write(yaml_data)
 
 
-def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str, train_input_model_name: str):
+def get_latest_entity_var(
+    creds: dict, siteconfig_path: str, project_path: str, train_input_model_name: str
+):
     connector = ConnectorFactory.create(creds, current_dir)
 
     latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -31,7 +31,7 @@ def create_site_config_file(creds, siteconfig_path):
 
 
 def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str):
-    connector = ConnectorFactory.create(creds["type"], creds)
+    connector = ConnectorFactory.create(creds)
 
     latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
         entity_key,
@@ -72,7 +72,7 @@ def validate_predictions_df_classification(creds: dict):
 
 
 def _validate_predictions_df(creds: dict, required_columns):
-    connector = ConnectorFactory.create(creds["type"], creds)
+    connector = ConnectorFactory.create(creds)
 
     try:
         df = connector.get_table_as_dataframe(connector.session, p_output_tablename)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -11,7 +11,8 @@ package_name = "feature_table"
 feature_table_name = "shopify_user_features"
 eligible_users = "1=1"
 package_name = "feature_table"
-label_column = "is_churned_7_days"
+classifier_label_column = "is_churned_7_days"
+regressor_label_column = "days_since_last_seen"
 inputs = [f"packages/{package_name}/models/{feature_table_name}"]
 s3_config = {}
 pred_horizon_days = 7

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -21,6 +21,7 @@ pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
 output_label = "OUTPUT_LABEL"
 p_output_tablename = "test_run_can_delete_2"
 entity_key = "user"
+train_input_model_name = "shopify_user_features"
 material_registry_table_name = "MATERIAL_REGISTRY_4"
 
 
@@ -48,8 +49,11 @@ def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str):
         latest_model_hash,
         entity_var_model_name,
     )
+    input_model_hash = connector.get_model_hash_from_registry(
+        material_registry_table_name, train_input_model_name, latest_seq_no
+    )
     connector.post_job_cleanup()
-    return entity_var_model_name, latest_model_hash, latest_seq_no
+    return input_model_hash, latest_seq_no
 
 
 def validate_predictions_df_regressor(creds: dict):

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,4 +1,23 @@
 import yaml
+from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
+    ConnectorFactory,
+)
+from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
+
+package_name = "feature_table"
+feature_table_name = "shopify_user_features"
+eligible_users = "1=1"
+package_name = "feature_table"
+label_column = "is_churned_7_days"
+inputs = [f"packages/{package_name}/models/{feature_table_name}"]
+s3_config = {}
+pred_horizon_days = 7
+output_model_name = "ltv_classification_integration_test"
+pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
+output_label = "OUTPUT_LABEL"
+p_output_tablename = "test_run_can_delete_2"
+entity_key = "user"
+material_registry_table_name = "MATERIAL_REGISTRY_4"
 
 
 def create_site_config_file(creds, siteconfig_path):
@@ -9,3 +28,63 @@ def create_site_config_file(creds, siteconfig_path):
     yaml_data = yaml.dump(json_data, default_flow_style=False)
     with open(siteconfig_path, "w") as file:
         file.write(yaml_data)
+
+
+def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str):
+    connector = ConnectorFactory.create(creds["type"], creds)
+
+    latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
+        entity_key,
+        siteconfig_path,
+        project_path,
+    )
+
+    latest_seq_no = connector.get_latest_seq_no_from_registry(
+        material_registry_table_name,
+        latest_model_hash,
+        entity_var_model_name,
+    )
+    connector.post_job_cleanup()
+    return entity_var_model_name, latest_model_hash, latest_seq_no
+
+
+def validate_predictions_df_regressor(creds: dict):
+    required_columns = [
+        "USER_MAIN_ID",
+        "VALID_AT",
+        pred_column,
+        "MODEL_ID",
+        f"PERCENTILE_{pred_column}",
+    ]
+    _validate_predictions_df(creds, required_columns)
+
+
+def validate_predictions_df_classification(creds: dict):
+    required_columns = [
+        "USER_MAIN_ID",
+        "VALID_AT",
+        pred_column,
+        "MODEL_ID",
+        output_label,
+        f"PERCENTILE_{pred_column}",
+    ]
+    _validate_predictions_df(creds, required_columns)
+
+
+def _validate_predictions_df(creds: dict, required_columns):
+    connector = ConnectorFactory.create(creds["type"], creds)
+
+    try:
+        df = connector.get_table_as_dataframe(connector.session, p_output_tablename)
+        columns_in_file = df.columns.tolist()
+    except Exception as e:
+        raise e
+    required_columns_lower = [column.lower() for column in required_columns]
+    columns_in_file_lower = [column.lower() for column in columns_in_file]
+
+    # Check if the required columns are present
+    if not set(required_columns_lower).issubset(columns_in_file_lower):
+        missing_columns = set(required_columns_lower) - set(columns_in_file_lower)
+        raise Exception(f"Miissing columns: {missing_columns} in predictions csv file.")
+
+    connector.post_job_cleanup()

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,8 +1,11 @@
+import os
 import yaml
 from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
     ConnectorFactory,
 )
 from src.predictions.rudderstack_predictions.wht.rudderPB import RudderPB
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
 
 package_name = "feature_table"
 feature_table_name = "shopify_user_features"
@@ -31,7 +34,7 @@ def create_site_config_file(creds, siteconfig_path):
 
 
 def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str):
-    connector = ConnectorFactory.create(creds)
+    connector = ConnectorFactory.create(creds, current_dir)
 
     latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(
         entity_key,
@@ -72,7 +75,7 @@ def validate_predictions_df_classification(creds: dict):
 
 
 def _validate_predictions_df(creds: dict, required_columns):
-    connector = ConnectorFactory.create(creds)
+    connector = ConnectorFactory.create(creds, current_dir)
 
     try:
         df = connector.get_table_as_dataframe(connector.session, p_output_tablename)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -21,7 +21,6 @@ pred_column = f"{output_model_name}_{pred_horizon_days}_days".upper()
 output_label = "OUTPUT_LABEL"
 p_output_tablename = "test_run_can_delete_2"
 entity_key = "user"
-train_input_model_name = "shopify_user_features"
 material_registry_table_name = "MATERIAL_REGISTRY_4"
 
 
@@ -35,7 +34,7 @@ def create_site_config_file(creds, siteconfig_path):
         file.write(yaml_data)
 
 
-def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str):
+def get_latest_entity_var(creds: dict, siteconfig_path: str, project_path: str, train_input_model_name: str):
     connector = ConnectorFactory.create(creds, current_dir)
 
     latest_model_hash, entity_var_model_name = RudderPB().get_latest_material_hash(

--- a/tests/unit/pyNativeWHT.py
+++ b/tests/unit/pyNativeWHT.py
@@ -8,7 +8,7 @@ class TestPyNativeWHT(unittest.TestCase):
     def setUp(self):
         self.whtMaterial = Mock()
         self.pyNativeWHT = PyNativeWHT(self.whtMaterial)
-        self.pyNativeWHT.init(None, None, None, None)
+        self.pyNativeWHT.init(None, None, None)
 
     def test_run(self):
         self.pyNativeWHT.pythonWHT.run = Mock()

--- a/tests/unit/pythonWHT.py
+++ b/tests/unit/pythonWHT.py
@@ -1,9 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
-from src.predictions.rudderstack_predictions.connectors.ConnectorFactory import (
-    ConnectorFactory,
-)
-from src.predictions.rudderstack_predictions.utils import utils
+from unittest.mock import patch
 from src.predictions.rudderstack_predictions.wht.pythonWHT import PythonWHT
 
 

--- a/tests/unit/pythonWHT.py
+++ b/tests/unit/pythonWHT.py
@@ -20,7 +20,6 @@ class TestGetInputModels(unittest.TestCase):
 
         self.pythonWHT.init(
             connector=None,
-            session=None,
             site_config_path="site_config",
             project_folder_path="project_folder",
         )


### PR DESCRIPTION
## Description of the change

- `Connector` class is now computing `self.session` in its `init` method
- Removed `session` argument from all the connector methods except for those which are called by Snowpark. Now `self.session` is being used. Had to do some hacky stuff to make it work for creating a `sproc`
- Extracted out common integration test to `utils` file

https://linear.app/rudderstack/issue/PRML-516/code-refactoring-make-session-object-a-member-of-connector-class

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
