### PR TITLE
Checking materialisations before running 'pb run'

### DIFF
--- a/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
+++ b/src/predictions/rudderstack_predictions/trainers/MLTrainer.py
@@ -394,26 +394,26 @@ class MLTrainer(ABC):
 
             try:
                 # Check wether the materialisation is already present
-                temp_materials = get_material_func(
+                existing_materials = get_material_func(
                     start_date=feature_date,
                     end_date=feature_date,
                     return_partial_pairs=True,
                 )
 
-                if len(temp_materials) > 0:
+                if len(existing_materials) > 0:
                     # Check if any full sequence is exist or not
                     complete_sequences = [
                         sequence
-                        for sequence in temp_materials
+                        for sequence in existing_materials
                         if all(element is not None for element in sequence)
                     ]
 
                     if len(complete_sequences) < 1:
-                        temp_material = temp_materials[0]
-                        if temp_material.feature_table_date is None:
+                        existing_material = existing_materials[0]
+                        if existing_material.feature_table_date is None:
                             whtService.run(feature_package_path, feature_date)
 
-                        if temp_material.label_table_date is None:
+                        if existing_material.label_table_date is None:
                             whtService.run(feature_package_path, label_date)
                 else:
                     for date in [feature_date, label_date]:
@@ -432,8 +432,8 @@ class MLTrainer(ABC):
             # and validate min data requirement again
 
             # For manual strategy, we need to get the materials for the selected dates separately
-            # because the selected dates may not be in the search window. so creating temporary start and end dates
-            # so that we can get the materials for the selected dates.
+            # because the selected dates may not be in the search window. so searching for materials
+            # with "feature_date" as start and end date.
 
             # This logic will be valid for "auto" strategy as well, so we are not handling it separately.
             materials += get_material_func(

--- a/src/predictions/rudderstack_predictions/utils/utils.py
+++ b/src/predictions/rudderstack_predictions/utils/utils.py
@@ -439,7 +439,7 @@ def date_add(reference_date: str, add_days: int) -> str:
 
 def get_abs_date_diff(ref_date1: str, ref_date2: str) -> int:
     """
-    For given two dates (in the format "YYYY-MM-DD") in string format, it will retrun the difference in days
+    For given two dates (in the format "YYYY-MM-DD") in string format, it will return the difference in days
     """
     d1 = datetime.strptime(ref_date1, constants.MATERIAL_DATE_FORMAT)
     d2 = datetime.strptime(ref_date2, constants.MATERIAL_DATE_FORMAT)

--- a/tests/unit/RedshiftConnector.py
+++ b/tests/unit/RedshiftConnector.py
@@ -979,8 +979,6 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
             connector=self.connector,
         )
 
-        print(f"Total call count pb run {mock_rudderpb_run.call_count}")
-
         # Assertions
         # We should be making only 3 calls to pb run, since one of the material dates is already present
         # in the registry

--- a/tests/unit/RedshiftConnector.py
+++ b/tests/unit/RedshiftConnector.py
@@ -852,7 +852,7 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
         mock_rudderpb_run.return_value = True
         mock_datetime_to_date_string.side_effect = ["2024-02-20", "2024-02-20"]
         mock_get_feature_package_path.return_value = "feature_package_path"
-        new_materials = self.materials + [
+        new_materials = [
             TrainTablesInfo(
                 feature_table_name="feature_table_name",
                 feature_table_date="2024-02-06 00:00:00",
@@ -861,7 +861,9 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
             ),
         ]
 
-        mock_get_material_func = Mock(return_value=new_materials)
+        mock_get_material_func = Mock(
+            side_effect=[[], new_materials, [], new_materials]
+        )
 
         mock_date_add.side_effect = [
             "2024-02-06",
@@ -874,7 +876,7 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
         self.trainer.check_min_data_requirement = Mock(side_effect=[False, True, True])
         result = self.trainer.check_and_generate_more_materials(
             mock_get_material_func,
-            materials=self.materials,
+            materials=self.materials.copy(),
             input_models=self.input_models,
             whtService=self.whtService,
             connector=self.connector,
@@ -885,7 +887,6 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
 
         # Verify calls to mock functions
         mock_get_feature_package_path.assert_called_once_with(self.input_models)
-        mock_datetime_to_date_string.assert_called()  # Called multiple times
         mock_rudderpb_run.assert_called()  # Called twice
 
         mock_dates_proximity_check.assert_called_once_with(
@@ -906,7 +907,7 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
         self.trainer.check_min_data_requirement = Mock(return_value=False)
         result = self.trainer.check_and_generate_more_materials(
             mock_get_material_func,
-            materials=self.materials,
+            materials=self.materials.copy(),
             input_models=self.input_models,
             whtService=self.whtService,
             connector=self.connector,
@@ -931,7 +932,7 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
         mock_datetime_to_date_string,
         mock_get_feature_package_path,
     ):
-        materials_1 = self.materials + [
+        materials_1 = [
             TrainTablesInfo(
                 feature_table_name="feature_table_name_1",
                 feature_table_date="2024-01-01 00:00:00",
@@ -940,7 +941,16 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
             ),
         ]
 
-        materials_2 = materials_1 + [
+        materials_2_partial = [
+            TrainTablesInfo(
+                feature_table_name="feature_table_name_2",
+                feature_table_date="2024-02-01 00:00:00",
+                label_table_name=None,
+                label_table_date=None,
+            ),
+        ]
+
+        materials_2 = [
             TrainTablesInfo(
                 feature_table_name="feature_table_name_2",
                 feature_table_date="2024-02-01 00:00:00",
@@ -949,8 +959,10 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
             ),
         ]
 
-        mock_rudderpb_run.side_effect = [True, True, True, True]
-        mock_get_material_func = Mock(side_effect=[materials_1, materials_2])
+        mock_rudderpb_run.side_effect = [True, True, True]
+        mock_get_material_func = Mock(
+            side_effect=[[], materials_1, materials_2_partial, materials_2]
+        )
         mock_get_feature_package_path.return_value = "feature_package_path"
 
         self.trainer.materialisation_dates = [
@@ -961,13 +973,19 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
         self.trainer.materialisation_strategy = "manual"
         result = self.trainer.check_and_generate_more_materials(
             mock_get_material_func,
-            materials=self.materials,
+            materials=self.materials.copy(),
             input_models=self.input_models,
             whtService=self.whtService,
             connector=self.connector,
         )
 
+        print(f"Total call count pb run {mock_rudderpb_run.call_count}")
+
         # Assertions
+        # We should be making only 3 calls to pb run, since one of the material dates is already present
+        # in the registry
+        self.assertEqual(mock_rudderpb_run.call_count, 3)  # Three materials generated
+
         self.assertEqual(len(result), 3)  # Three materials generated
 
         # Verify calls to mock functions
@@ -982,7 +1000,7 @@ class TestCheckAndGenerateMoreMaterials(unittest.TestCase):
 
         result = self.trainer.check_and_generate_more_materials(
             mock_get_material_func,
-            materials=self.materials,
+            materials=self.materials.copy(),
             input_models=self.input_models,
             whtService=self.whtService,
             connector=self.connector,


### PR DESCRIPTION
## Description of the change

- [ ] Modified `get_material_names` to return partial pairs so that `pb run` will be skipped for already materialised dates
- [ ] Modified `check_and_generate_more_materials` method to check for existing materialisations for both `auto` and `manual` strategy. Fixing issue related searching newly materialised dates with newly generated/configured feature date 
- [ ] Updated Redshift unit test cases to address new changes.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
