### PR TITLE
fix: use local mode instead of k8s mode for non-Snowflake warehouses

### DIFF
--- a/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/rudderstack_predictions/connectors/CommonWarehouseConnector.py
@@ -117,12 +117,12 @@ class CommonWarehouseConnector(Connector):
     def fetch_processor_mode(
         self, user_preference_order_infra: List[str], is_rudder_backend: bool
     ) -> str:
-        mode = (
-            constants.RUDDERSTACK_MODE
-            if is_rudder_backend
-            else user_preference_order_infra[0]
-        )
-        return mode
+        # mode = (
+        #     constants.RUDDERSTACK_MODE
+        #     if is_rudder_backend
+        #     else user_preference_order_infra[0]
+        # )
+        return constants.LOCAL_MODE
 
     def compute_udf_name(self, model_path: str) -> None:
         return

--- a/src/predictions/rudderstack_predictions/connectors/wh/redshift_base_connector.py
+++ b/src/predictions/rudderstack_predictions/connectors/wh/redshift_base_connector.py
@@ -45,7 +45,9 @@ class RedShiftConnector(ConnectorBase):
         logger.debug("Redshift write_to_table")
 
         try:
-            if not self.s3_config:
+            # Instead of checking aws_access_key_id key, we could have also checked for either access_key_secret or aws_session_token key
+            # The assumption is either all the three keys are present or none of them are present
+            if not self.s3_config or not self.s3_config.get("aws_access_key_id", None):
                 df.to_sql(
                     name=table_name.lower(),
                     con=self.engine,


### PR DESCRIPTION
## Description of the change

ML model is currently broken in the UI. So changing the k8s mode to local mode now that we are using a separate pod. With this change, Redshift writes won't happen via S3. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
