### PR TITLE
Added caching functionality

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/llm.py
+++ b/src/predictions/profiles_mlcorelib/py_native/llm.py
@@ -103,9 +103,11 @@ class LLMModelRecipe(PyNativeRecipe):
         var_table_ref = (
             f"this.DeRef(makePath({self.prompt_inputs[0]}.Model.GetVarTableRef()))"
         )
-        # Joined_columns used to create a comma seperated string
+        # Joined_columns used to create a comma seperated string in order to mention
+        # all the columns that are used as input in the query.
         joined_columns = ", ".join(input_columns)
-        # Join condition to join the predicted column to the original table
+        # Join condition to join the predicted column to the original table in order to mention
+        # all the column that are being used in the input columns list.
         join_condition = " AND ".join([f"a.{col} = b.{col}" for col in input_columns])
 
         # model_creator_sql
@@ -113,7 +115,8 @@ class LLMModelRecipe(PyNativeRecipe):
             {{% macro begin_block() %}}
                 {{% macro selector_sql() %}}
                     {{% set entityVarTable = {var_table_ref} %}}
-                    # Common Table Expression (CTE) to get distinct values of specified columns
+                    # Common Table Expression (CTE) to get distinct values of specified columns in order to
+                    # reduce the number of api calls for the llm model.
                         WITH distinct_attribute AS (
                         SELECT DISTINCT {joined_columns}
                         FROM {{{{entityVarTable}}}}
@@ -124,7 +127,8 @@ class LLMModelRecipe(PyNativeRecipe):
                     )
                         SELECT a.{entity_id_column_name}, b.{column_name}
                         FROM {{{{entityVarTable}}}} a
-                        # Perform a LEFT JOIN between the original table and the predicted attributes
+                        # Perform a LEFT JOIN between the original table and the predicted attributes to fill all the 
+                        # attribute value with their corresponding predicted value.
                         LEFT JOIN predicted_attribute b ON {join_condition}
                 {{% endmacro %}}
                 {{% exec %}} {{{{warehouse.CreateReplaceTableAs(this.Name(), selector_sql())}}}} {{% endexec %}}

--- a/src/predictions/profiles_mlcorelib/py_native/llm.py
+++ b/src/predictions/profiles_mlcorelib/py_native/llm.py
@@ -103,18 +103,27 @@ class LLMModelRecipe(PyNativeRecipe):
         var_table_ref = (
             f"this.DeRef(makePath({self.prompt_inputs[0]}.Model.GetVarTableRef()))"
         )
+        joined_columns = ", ".join(input_columns)
+        join_condition = " AND ".join([f"a.{col} = b.{col}" for col in input_columns])
 
         # model_creator_sql
         query_template = f"""
             {{% macro begin_block() %}}
                 {{% macro selector_sql() %}}
                     {{% set entityVarTable = {var_table_ref} %}}
-
-                    SELECT {entity_id_column_name}, SNOWFLAKE.CORTEX.COMPLETE('{self.llm_model_name}','{prompt_replaced}') AS {column_name} FROM {{{{entityVarTable}}}}
+                        WITH distinct_names AS (
+                        SELECT DISTINCT {joined_columns}
+                        FROM {{{{entityVarTable}}}}
+                    ), predicted_gender AS (
+                        SELECT {joined_columns}, SNOWFLAKE.CORTEX.COMPLETE('{self.llm_model_name}','{prompt_replaced}') AS {column_name},
+                        FROM distinct_names
+                    )
+                        SELECT a.{entity_id_column_name}, b.{column_name}
+                        FROM {{{{entityVarTable}}}} a
+                        LEFT JOIN predicted_gender b ON {join_condition}
                 {{% endmacro %}}
                 {{% exec %}} {{{{warehouse.CreateReplaceTableAs(this.Name(), selector_sql())}}}} {{% endexec %}}
             {{% endmacro %}}
-
             {{% exec %}} {{{{warehouse.BeginEndBlock(begin_block())}}}} {{% endexec %}}"""
 
         self.sql = this.execute_text_template(query_template)

--- a/src/predictions/profiles_mlcorelib/py_native/llm.py
+++ b/src/predictions/profiles_mlcorelib/py_native/llm.py
@@ -111,16 +111,16 @@ class LLMModelRecipe(PyNativeRecipe):
             {{% macro begin_block() %}}
                 {{% macro selector_sql() %}}
                     {{% set entityVarTable = {var_table_ref} %}}
-                        WITH distinct_names AS (
+                        WITH distinct_attribute AS (
                         SELECT DISTINCT {joined_columns}
                         FROM {{{{entityVarTable}}}}
-                    ), predicted_gender AS (
+                    ), predicted_attribute AS (
                         SELECT {joined_columns}, SNOWFLAKE.CORTEX.COMPLETE('{self.llm_model_name}','{prompt_replaced}') AS {column_name},
-                        FROM distinct_names
+                        FROM distinct_attribute
                     )
                         SELECT a.{entity_id_column_name}, b.{column_name}
                         FROM {{{{entityVarTable}}}} a
-                        LEFT JOIN predicted_gender b ON {join_condition}
+                        LEFT JOIN predicted_attribute b ON {join_condition}
                 {{% endmacro %}}
                 {{% exec %}} {{{{warehouse.CreateReplaceTableAs(this.Name(), selector_sql())}}}} {{% endexec %}}
             {{% endmacro %}}

--- a/src/predictions/profiles_mlcorelib/py_native/llm.py
+++ b/src/predictions/profiles_mlcorelib/py_native/llm.py
@@ -136,7 +136,7 @@ class LLMModelRecipe(PyNativeRecipe):
             {{% exec %}} {{{{warehouse.BeginEndBlock(begin_block())}}}} {{% endexec %}}"""
 
         self.sql = this.execute_text_template(query_template)
-        return 
+        return
 
     def execute(self, this: WhtMaterial):
         this.wht_ctx.client.query_sql_without_result(self.sql)


### PR DESCRIPTION
## Description of the change

Added caching functionality:
Made changes to the SQL Query. 
1. First we are selecting a distinct attribute values, on which snowflake cortex will be run.
2. Ones the output is received from the cortex, it is mapped again to the original table.
3. In this way the number of api hits made to the LLM model is reduced by using only distinct attribute values.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
