### PR TITLE
chore: add long_description_content_type to fix publish error

### DIFF
--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -6,6 +6,12 @@ setup(
     version=version,
     author="rudderstack",
     packages=find_packages(),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License"
+    ],
     install_requires=[
         "profiles_rudderstack>=0.11.1",
         "cachetools>=5.3.2",

--- a/src/predictions/version.py
+++ b/src/predictions/version.py
@@ -1,1 +1,1 @@
-version = "0.1.0"
+version = "0.0.0"


### PR DESCRIPTION
## Description of the change

Checking dist/profiles_mlcorelib-0.1.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source.                                   
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking dist/profiles_mlcorelib-0.1.0.tar.gz: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
WARNING  `long_description` missing.  

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
