### PR TITLE
correcting fn name

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/llm.py
+++ b/src/predictions/profiles_mlcorelib/py_native/llm.py
@@ -96,7 +96,7 @@ class LLMModelRecipe(PyNativeRecipe):
     def describe(self, this: WhtMaterial):
         return self.sql, ".sql"
 
-    def prepare(self, this: WhtMaterial):
+    def register_dependencies(self, this: WhtMaterial):
         entity = this.model.entity()
         column_name = this.model.name()
         if entity is None:


### PR DESCRIPTION
## Description of the change

> in pb version>=0.13.0, name of prepare() has been changed to register_dependencies().

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
