### PR TITLE
 feat: integrate py native logger with predictions code 

### DIFF
--- a/scripts/simulate_pb_run.py
+++ b/scripts/simulate_pb_run.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         or label_column is None
         or train_inputs is None
     ):
-        logger.error("One or more required environment variable(s) are not set")
+        logger.get().error("One or more required environment variable(s) are not set")
         sys.exit(1)
 
     train_file_extension = ".json"
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         creds = yaml.safe_load(f)["connections"][connection_name]["outputs"][env_name]
 
     # End of user inputs.
-    logger.setLevel("DEBUG")
+    logger.get().setLevel("DEBUG")
 
     if creds["type"] == "snowflake":
         print(
@@ -131,10 +131,10 @@ if __name__ == "__main__":
     try:
         train_inputs = train_inputs.split(",")
     except Exception as e:
-        logger.error(f"Error parsing train inputs: {str(e)}")
+        logger.get().error(f"Error parsing train inputs: {str(e)}")
         raise Exception(f"Error parsing train inputs: {str(e)}")
 
-    logger.info(f"Training inputs: {train_inputs}")
+    logger.get().info(f"Training inputs: {train_inputs}")
     if should_train:
         T.train(
             creds,

--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -695,7 +695,7 @@ class CommonWarehouseConnector(Connector):
             total_samples < min_no_of_samples
             or total_negative_samples < min_negative_label_count
         ):
-            logger.debug(
+            logger.get().debug(
                 "Total number of samples or number of negative samples are "
                 "not meeting the minimum training requirement, "
                 f"total samples - {total_samples}, minimum samples required - {min_no_of_samples}, "
@@ -727,7 +727,7 @@ class CommonWarehouseConnector(Connector):
         min_no_of_samples = constants.MIN_NUM_OF_SAMPLES
 
         if total_samples < min_no_of_samples:
-            logger.debug(
+            logger.get().debug(
                 "Number training samples are not meeting the minimum requirement, "
                 f"total samples - {total_samples}, minimum samples required - {min_no_of_samples}"
             )
@@ -955,9 +955,9 @@ class CommonWarehouseConnector(Connector):
     def delete_local_data_folder(self) -> None:
         try:
             shutil.rmtree(self.local_dir)
-            logger.info("Local directory removed successfully")
+            logger.get().info("Local directory removed successfully")
         except OSError as o:
-            logger.info("Local directory not present")
+            logger.get().info("Local directory not present")
             pass
 
     def pre_job_cleanup(self) -> None:

--- a/src/predictions/profiles_mlcorelib/connectors/ConnectorFactory.py
+++ b/src/predictions/profiles_mlcorelib/connectors/ConnectorFactory.py
@@ -7,7 +7,7 @@ from .SnowflakeConnector import SnowflakeConnector
 try:
     from .BigQueryConnector import BigQueryConnector
 except Exception as e:
-    logger.warning(f"Could not import BigQueryConnector")
+    logger.get().warning(f"Could not import BigQueryConnector")
 
 
 class ConnectorFactory:

--- a/src/predictions/profiles_mlcorelib/connectors/ConnectorFactory.py
+++ b/src/predictions/profiles_mlcorelib/connectors/ConnectorFactory.py
@@ -7,7 +7,7 @@ from .SnowflakeConnector import SnowflakeConnector
 try:
     from .BigQueryConnector import BigQueryConnector
 except Exception as e:
-    logger.get().warning(f"Could not import BigQueryConnector")
+    logger.get().error(f"Could not import BigQueryConnector")
 
 
 class ConnectorFactory:

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -917,7 +917,7 @@ class SnowflakeConnector(Connector):
             total_samples < min_no_of_samples
             or total_negative_samples < min_negative_label_count
         ):
-            logger.debug(
+            logger.get().debug(
                 "Total number of samples or number of negative samples are "
                 "not meeting the minimum training requirement, "
                 f"total samples - {total_samples}, minimum samples required - {min_no_of_samples}, "
@@ -943,7 +943,7 @@ class SnowflakeConnector(Connector):
         min_no_of_samples = constants.MIN_NUM_OF_SAMPLES
 
         if total_samples < min_no_of_samples:
-            logger.debug(
+            logger.get().debug(
                 "Number training samples are not meeting the minimum requirement, "
                 f"total samples - {total_samples}, minimum samples required - {min_no_of_samples}"
             )
@@ -1101,7 +1101,7 @@ class SnowflakeConnector(Connector):
     ) -> None:
         all_stages = self.run_query(f"show stages like '{stage_name.replace('@', '')}'")
         if len(all_stages) == 0:
-            logger.info(f"Stage {stage_name} does not exist. No files to delete.")
+            logger.get().info(f"Stage {stage_name} does not exist. No files to delete.")
             return
 
         import_files = [element.split("/")[-1] for element in import_paths]
@@ -1126,17 +1126,17 @@ class SnowflakeConnector(Connector):
         """
         fn_list = self.session.sql(f"show user functions like '{fn_name}'").collect()
         if len(fn_list) == 0:
-            logger.info(f"Function {fn_name} does not exist")
+            logger.get().info(f"Function {fn_name} does not exist")
             return True
         else:
-            logger.info(
+            logger.get().info(
                 "Function name match found. Dropping all functions with the same name"
             )
             for fn in fn_list:
                 fn_signature = fn["arguments"].split("RETURN")[0]
                 drop = self.session.sql(f"DROP FUNCTION IF EXISTS {fn_signature}")
-                logger.info(drop.collect()[0].status)
-            logger.info("All functions with the same name dropped")
+                logger.get().info(drop.collect()[0].status)
+            logger.get().info("All functions with the same name dropped")
             return True
 
     def get_file(

--- a/src/predictions/profiles_mlcorelib/connectors/wh/bigquery_base_connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/wh/bigquery_base_connector.py
@@ -42,5 +42,5 @@ class BigqueryConnector(ConnectorBase):
             )
 
         except Exception as e:
-            logger.error(f"Error while writing to warehouse: {e}")
+            logger.get().error(f"Error while writing to warehouse: {e}")
             raise Exception(f"Error while writing to warehouse: {e}")

--- a/src/predictions/profiles_mlcorelib/connectors/wh/redshift_base_connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/wh/redshift_base_connector.py
@@ -42,7 +42,7 @@ class RedShiftConnector(ConnectorBase):
         table_name, schema = (
             table_name.split(".") if "." in table_name else (table_name, schema)
         )
-        logger.debug("Redshift write_to_table")
+        logger.get().debug("Redshift write_to_table")
 
         try:
             # Instead of checking access_key_id key, we could have also checked for either access_key_secret or aws_session_token key
@@ -57,7 +57,7 @@ class RedShiftConnector(ConnectorBase):
                     method="multi",
                 )
             else:
-                logger.info(f"Establishing connection to Redshift")
+                logger.get().info(f"Establishing connection to Redshift")
                 pr.connect_to_redshift(
                     dbname=self.db_config["database"],
                     host=self.creds["host"],
@@ -69,7 +69,7 @@ class RedShiftConnector(ConnectorBase):
                 s3_bucket = self.s3_config.get("bucket", None)
                 s3_sub_dir = self.s3_config.get("path", None)
 
-                logger.info(f"Establishing connection to S3")
+                logger.get().info(f"Establishing connection to S3")
                 pr.connect_to_s3(
                     aws_access_key_id=self.s3_config["access_key_id"],
                     aws_secret_access_key=self.s3_config["access_key_secret"],
@@ -80,15 +80,15 @@ class RedShiftConnector(ConnectorBase):
                 )
 
                 # Write the DataFrame to S3 and then to redshift
-                logger.info(f"Writing pandas df to S3 and then to Redshift")
+                logger.get().info(f"Writing pandas df to S3 and then to Redshift")
                 pr.pandas_to_redshift(
                     data_frame=df,
                     redshift_table_name=f"{schema}.{table_name}",
                     append=if_exists == "append",
                 )
-                logger.info(
+                logger.get().info(
                     f"Successfully wrote table {table_name} to S3 and then to Redshift"
                 )
         except Exception as e:
-            logger.error(f"Error while writing to warehouse: {e}")
+            logger.get().error(f"Error while writing to warehouse: {e}")
             raise Exception(f"Error while writing to warehouse: {e}")

--- a/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
+++ b/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
@@ -91,16 +91,16 @@ def preprocess_and_predict(
         seq_no,
     )
 
-    logger.debug(f"Pulling data from Entity-Var table - {entity_var_table_name}")
+    logger.get().debug(f"Pulling data from Entity-Var table - {entity_var_table_name}")
     raw_data = connector.get_table(
         entity_var_table_name, filter_condition=trainer.eligible_users
     )
 
-    logger.debug("Transforming timestamp columns.")
+    logger.get().debug("Transforming timestamp columns.")
     for col in timestamp_columns:
         raw_data = connector.add_days_diff(raw_data, col, col, end_ts)
 
-    logger.debug(f"Transforming arraytype columns.")
+    logger.get().debug(f"Transforming arraytype columns.")
     _, raw_data = connector.transform_arraytype_features(
         raw_data,
         arraytype_columns,
@@ -109,7 +109,7 @@ def preprocess_and_predict(
     )
     raw_data = connector.transform_booleantype_features(raw_data, booleantype_columns)
 
-    logger.debug("Boolean Type Columns transformed to numeric")
+    logger.get().debug("Boolean Type Columns transformed to numeric")
 
     predict_data = connector.drop_cols(raw_data, ignore_features)
 
@@ -188,7 +188,7 @@ def preprocess_and_predict(
 
         prediction_udf = predict_scores_rs
 
-    logger.debug("Creating predictions on the feature data")
+    logger.get().debug("Creating predictions on the feature data")
     preds_with_percentile = connector.call_prediction_udf(
         predict_data,
         prediction_udf,
@@ -201,7 +201,7 @@ def preprocess_and_predict(
         prob_th,
         input_df,
     )
-    logger.debug("Writing predictions to warehouse")
+    logger.get().debug("Writing predictions to warehouse")
     connector.write_table(
         preds_with_percentile,
         output_tablename,
@@ -219,7 +219,7 @@ def preprocess_and_predict(
             whtService.get_registry_table_name(),
         )
 
-        logger.debug(f"Fetching previous prediction table: {prev_prediction_table}")
+        logger.get().debug(f"Fetching previous prediction table: {prev_prediction_table}")
         prev_predictions = connector.get_table(prev_prediction_table)
 
         label_table = trainer.prepare_label_table(connector, entity_var_table_name)
@@ -281,12 +281,12 @@ def preprocess_and_predict(
 
             connector.write_pandas(metrics_df, f"{metrics_table}", if_exists="append")
     except Exception as e:
-        logger.warning(f"Error while fetching previous prediction table: {e}")
+        logger.get().warning(f"Error while fetching previous prediction table: {e}")
 
-    logger.debug("Closing the session")
+    logger.get().debug("Closing the session")
 
     connector.post_job_cleanup()
-    logger.debug("Finished Predict job")
+    logger.get().debug("Finished Predict job")
 
 
 if __name__ == "__main__":
@@ -319,10 +319,10 @@ if __name__ == "__main__":
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+    logger.get().addHandler(file_handler)
 
     if args.mode == constants.RUDDERSTACK_MODE:
-        logger.debug(f"Downloading files from S3 in {args.mode} mode.")
+        logger.get().debug(f"Downloading files from S3 in {args.mode} mode.")
         S3Utils.download_directory(args.s3_config, output_dir)
     if args.mode == constants.CI_MODE:
         sys.exit(0)
@@ -344,5 +344,5 @@ if __name__ == "__main__":
     )
 
     if args.mode == constants.RUDDERSTACK_MODE:
-        logger.debug(f"Deleting files in {output_dir}")
+        logger.get().debug(f"Deleting files in {output_dir}")
         utils.delete_folder(output_dir)

--- a/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
+++ b/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
@@ -219,7 +219,9 @@ def preprocess_and_predict(
             whtService.get_registry_table_name(),
         )
 
-        logger.get().debug(f"Fetching previous prediction table: {prev_prediction_table}")
+        logger.get().debug(
+            f"Fetching previous prediction table: {prev_prediction_table}"
+        )
         prev_predictions = connector.get_table(prev_prediction_table)
 
         label_table = trainer.prepare_label_table(connector, entity_var_table_name)
@@ -281,7 +283,7 @@ def preprocess_and_predict(
 
             connector.write_pandas(metrics_df, f"{metrics_table}", if_exists="append")
     except Exception as e:
-        logger.get().warning(f"Error while fetching previous prediction table: {e}")
+        logger.get().error(f"Error while fetching previous prediction table: {e}")
 
     logger.get().debug("Closing the session")
 

--- a/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_train.py
+++ b/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_train.py
@@ -204,7 +204,9 @@ def preprocess_and_train(
         transformed_arraytype_cols,
         transformed_booleantype_cols,
     )
-    logger.get().debug(f"Feature_table column types detected: {feature_table_column_types}")
+    logger.get().debug(
+        f"Feature_table column types detected: {feature_table_column_types}"
+    )
 
     task_type = trainer.get_name()
     logger.get().debug(f"Performing data validation for {task_type}")
@@ -318,7 +320,9 @@ if __name__ == "__main__":
         json.dump(train_results_json, file)
 
     if args.mode == constants.RUDDERSTACK_MODE:
-        logger.get().debug(f"Uploading trained files to s3://{args.s3_bucket}/{args.s3_path}")
+        logger.get().debug(
+            f"Uploading trained files to s3://{args.s3_bucket}/{args.s3_path}"
+        )
 
         train_upload_whitelist = utils.merge_lists_to_unique(
             list(trainer.figure_names.values()),
@@ -335,5 +339,7 @@ if __name__ == "__main__":
             train_upload_whitelist,
         )
 
-        logger.get().debug(f"Deleting additional local directory from {args.mode} mode.")
+        logger.get().debug(
+            f"Deleting additional local directory from {args.mode} mode."
+        )
         connector.delete_local_data_folder()

--- a/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_train.py
+++ b/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_train.py
@@ -63,14 +63,14 @@ def train_and_store_model_results(
     train_x, test_x, test_y, pipe, model_id, metrics_df, results = trainer.train_model(
         feature_df, categorical_columns, numeric_columns, train_config, model_file
     )
-    logger.info(f"Generating plots and saving them to the output directory.")
+    logger.get().info(f"Generating plots and saving them to the output directory.")
     trainer.plot_diagnostics(
         connector, connector.session, pipe, None, test_x, test_y, trainer.label_column
     )
     figure_file = connector.join_file_path(
         trainer.figure_names["feature-importance-chart"]
     )
-    logger.info(f"Generating feature importance plot")
+    logger.get().info(f"Generating feature importance plot")
     utils.plot_top_k_feature_importance(
         pipe,
         train_x,
@@ -149,9 +149,9 @@ def preprocess_and_train(
     train_config = merged_config["train"]
 
     feature_table = None
-    logger.info("Preparing training dataset using the past snapshot tables:")
+    logger.get().info("Preparing training dataset using the past snapshot tables:")
     for train_table_pair in train_table_pairs:
-        logger.info(
+        logger.get().info(
             f"\t\tFeature table: {train_table_pair.feature_table_name}\tLabel table: {train_table_pair.label_table_name}"
         )
         feature_table_instance = prepare_feature_table(
@@ -171,7 +171,7 @@ def preprocess_and_train(
         trainer.entity_column,
         cardinal_feature_threshold,
     )
-    logger.info(
+    logger.get().info(
         f"Following features are detected as having high cardinality, and will be ignored for training: {high_cardinal_features}"
     )
 
@@ -185,17 +185,17 @@ def preprocess_and_train(
         feature_table, input_column_types["booleantype"]
     )
     transformed_booleantype_cols = input_column_types["booleantype"]
-    logger.debug("Boolean Type Columns transformed to numeric")
+    logger.get().debug("Boolean Type Columns transformed to numeric")
 
     ignore_features = utils.get_all_ignore_features(
         feature_table,
         trainer.prep.ignore_features,
         high_cardinal_features,
     )
-    logger.info(f"List of all features to be ignored: {ignore_features}")
+    logger.get().info(f"List of all features to be ignored: {ignore_features}")
     feature_table = connector.drop_cols(feature_table, ignore_features)
 
-    logger.debug("Fetching feature table column types")
+    logger.get().debug("Fetching feature table column types")
     feature_table_column_types = utils.get_feature_table_column_types(
         feature_table,
         input_column_types,
@@ -204,13 +204,13 @@ def preprocess_and_train(
         transformed_arraytype_cols,
         transformed_booleantype_cols,
     )
-    logger.debug(f"Feature_table column types detected: {feature_table_column_types}")
+    logger.get().debug(f"Feature_table column types detected: {feature_table_column_types}")
 
     task_type = trainer.get_name()
-    logger.debug(f"Performing data validation for {task_type}")
+    logger.get().debug(f"Performing data validation for {task_type}")
 
     trainer.validate_data(connector, feature_table)
-    logger.debug("Data validation is completed")
+    logger.get().debug("Data validation is completed")
 
     filtered_feature_table = connector.filter_feature_table(
         feature_table,
@@ -224,7 +224,7 @@ def preprocess_and_train(
         if_exists="replace",
     )
 
-    logger.info("Training and fetching the results")
+    logger.get().info("Training and fetching the results")
     try:
         train_results_json = connector.call_procedure(
             train_procedure,
@@ -236,13 +236,13 @@ def preprocess_and_train(
             trainer=trainer,
         )
     except Exception as e:
-        logger.error(f"Error while training the model: {e}")
+        logger.get().error(f"Error while training the model: {e}")
         raise e
 
     if not isinstance(train_results_json, dict):
         train_results_json = json.loads(train_results_json)
 
-    logger.info("Saving column names info. to the output json.")
+    logger.get().info("Saving column names info. to the output json.")
     train_results_json["column_names"] = {}
     train_results_json["column_names"]["input_column_types"] = input_column_types
     train_results_json["column_names"]["ignore_features"] = ignore_features
@@ -284,7 +284,7 @@ if __name__ == "__main__":
     )
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+    logger.get().addHandler(file_handler)
 
     if args.mode == constants.CI_MODE:
         sys.exit(0)
@@ -318,7 +318,7 @@ if __name__ == "__main__":
         json.dump(train_results_json, file)
 
     if args.mode == constants.RUDDERSTACK_MODE:
-        logger.debug(f"Uploading trained files to s3://{args.s3_bucket}/{args.s3_path}")
+        logger.get().debug(f"Uploading trained files to s3://{args.s3_bucket}/{args.s3_path}")
 
         train_upload_whitelist = utils.merge_lists_to_unique(
             list(trainer.figure_names.values()),
@@ -335,5 +335,5 @@ if __name__ == "__main__":
             train_upload_whitelist,
         )
 
-        logger.debug(f"Deleting additional local directory from {args.mode} mode.")
+        logger.get().debug(f"Deleting additional local directory from {args.mode} mode.")
         connector.delete_local_data_folder()

--- a/src/predictions/profiles_mlcorelib/predict.py
+++ b/src/predictions/profiles_mlcorelib/predict.py
@@ -35,7 +35,7 @@ def _predict(
     runtime_info: dict,
     ml_core_path: str,
 ) -> None:
-    logger.debug("Starting Predict job")
+    logger.get().debug("Starting Predict job")
 
     is_rudder_backend = utils.fetch_key_from_dict(
         runtime_info, "is_rudder_backend", False
@@ -55,7 +55,7 @@ def _predict(
     )
     trainer = TrainerFactory.create(merged_config)
 
-    logger.debug(
+    logger.get().debug(
         f"Started Predicting for {trainer.output_profiles_ml_model} to predict {trainer.label_column}"
     )
     connector = ConnectorFactory.create(creds, folder_path)
@@ -67,7 +67,7 @@ def _predict(
         user_preference_order_infra, is_rudder_backend
     )
     processor = ProcessorFactory.create(mode, trainer, connector, ml_core_path)
-    logger.debug(f"Using {mode} processor for predictions")
+    logger.get().debug(f"Using {mode} processor for predictions")
 
     site_config = utils.load_yaml(site_config_path)
     presets = site_config["py_models"].get("credentials_presets")

--- a/src/predictions/profiles_mlcorelib/processors/LocalProcessor.py
+++ b/src/predictions/profiles_mlcorelib/processors/LocalProcessor.py
@@ -65,7 +65,7 @@ class LocalProcessor(Processor):
         output_path = os.path.dirname(model_path)
         json_output_filename = model_path.split("/")[-1]
 
-        logger.debug("Starting prediction on local processing mode")
+        logger.get().debug("Starting prediction on local processing mode")
         commands = [
             sys.executable,
             "-u",
@@ -93,4 +93,4 @@ class LocalProcessor(Processor):
             raise Exception(
                 f"Error occurred while running predict script in local processing mode. Error: {response_for_predict.stderr}"
             )
-        logger.debug("Done predicting")
+        logger.get().debug("Done predicting")

--- a/src/predictions/profiles_mlcorelib/py_native/prediction.py
+++ b/src/predictions/profiles_mlcorelib/py_native/prediction.py
@@ -13,6 +13,7 @@ from .training import TrainingRecipe
 
 from ..predict import _predict
 from ..utils import constants
+from ..utils.logger import logger
 
 
 class PredictionModel(BaseModelType):
@@ -97,6 +98,7 @@ class PredictionRecipe(PyNativeRecipe):
         return TrainingRecipe.get_training_file_path(train_material)
 
     def execute(self, this: WhtMaterial):
+        logger.set_logger(self.logger)
         site_config_path = this.wht_ctx.site_config().get("FilePath")
         whtService = PyNativeWHT(this)
         # TODO: Get creds from pywht

--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -5,6 +5,8 @@ from profiles_rudderstack.material import WhtMaterial
 from profiles_rudderstack.logger import Logger
 from profiles_rudderstack.schema import EntityKeyBuildSpecSchema
 
+from ..utils.logger import logger
+
 from .warehouse import standardize_ref_name
 
 from ..utils import constants
@@ -85,6 +87,7 @@ class TrainingRecipe(PyNativeRecipe):
         return f"{folder}/{this.name()}/training_file"
 
     def execute(self, this: WhtMaterial):
+        logger.set_logger(self.logger)
         whtService = PyNativeWHT(this)
         site_config_path = this.wht_ctx.site_config().get("FilePath")
         # TODO: Get creds from pywht

--- a/src/predictions/profiles_mlcorelib/train.py
+++ b/src/predictions/profiles_mlcorelib/train.py
@@ -264,7 +264,9 @@ def _train(
 
     absolute_input_models = whtService.get_input_models(inputs)
 
-    logger.get().info(f"Getting input column types from table: {latest_entity_var_table}")
+    logger.get().info(
+        f"Getting input column types from table: {latest_entity_var_table}"
+    )
     input_column_types = connector.get_input_column_types(
         trainer,
         latest_entity_var_table,
@@ -367,7 +369,7 @@ def _train(
         try:
             connector.fetch_staged_file(stage_name, figure_name, reports_directory)
         except Exception as e:
-            logger.get().warning(f"Could not fetch {figure_name} {e}")
+            logger.get().error(f"Could not fetch {figure_name} {e}")
 
     logger.get().debug("Cleaning up the training session")
     connector.post_job_cleanup()

--- a/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
+++ b/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
@@ -102,7 +102,7 @@ class MLTrainer(ABC):
                     f"feature_data_min_date_diff required for auto materialisation strategy. {e} not found in input config"
                 )
         elif self.materialisation_strategy == "":
-            logger.info(
+            logger.get().info(
                 "No past materialisation strategy given. The training will be done on the existing eligible past materialised data only."
             )
 
@@ -135,7 +135,7 @@ class MLTrainer(ABC):
                 error_message = (
                     f"Invalid num_params_name: {num_params_name} for numeric pipeline."
                 )
-                logger.error(error_message)
+                logger.get().error(error_message)
                 raise ValueError(error_message)
         num_pipeline = Pipeline(
             [
@@ -152,7 +152,7 @@ class MLTrainer(ABC):
             except AssertionError:
                 error_message = f"Invalid cat_params_name: {cat_params_name} for categorical pipeline."
 
-                logger.error(error_message)
+                logger.get().error(error_message)
                 raise ValueError(error_message)
 
         cat_pipeline = Pipeline(
@@ -341,8 +341,8 @@ class MLTrainer(ABC):
     ):
         met_data_requirement = self.check_min_data_requirement(connector, materials)
 
-        logger.debug(f"Min data requirement satisfied: {met_data_requirement}")
-        logger.debug(
+        logger.get().debug(f"Min data requirement satisfied: {met_data_requirement}")
+        logger.get().debug(
             f"New material generation strategy : {self.materialisation_strategy}"
         )
         if met_data_requirement or self.materialisation_strategy == "":
@@ -367,7 +367,7 @@ class MLTrainer(ABC):
                 training_dates = [
                     date_str for date_str in training_dates if len(date_str) != 0
                 ]
-                logger.info(f"training_dates : {training_dates}")
+                logger.get().info(f"training_dates : {training_dates}")
                 training_dates = sorted(
                     training_dates,
                     key=lambda x: datetime.strptime(x, MATERIAL_DATE_FORMAT),
@@ -384,7 +384,7 @@ class MLTrainer(ABC):
                     self.prediction_horizon_days,
                     self.feature_data_min_date_diff,
                 )
-                logger.info(
+                logger.get().info(
                     f"new generated dates for feature: {feature_date}, label: {label_date}"
                 )
             elif self.materialisation_strategy == "manual":
@@ -423,11 +423,11 @@ class MLTrainer(ABC):
                     for date in [feature_date, label_date]:
                         whtService.run(feature_package_path, date)
             except Exception as e:
-                logger.warning(str(e))
-                logger.warning("Stopped generating new material dates.")
+                logger.get().warning(str(e))
+                logger.get().warning("Stopped generating new material dates.")
                 break
 
-            logger.info(
+            logger.get().info(
                 "Materialised feature and label data successfully, "
                 f"for dates {feature_date} and {label_date}"
             )
@@ -444,18 +444,18 @@ class MLTrainer(ABC):
                 start_date=feature_date, end_date=feature_date
             )
 
-            logger.debug(
+            logger.get().debug(
                 f"new feature tables: {[m.feature_table_name for m in materials]}"
             )
-            logger.debug(f"new label tables: {[m.label_table_name for m in materials]}")
+            logger.get().debug(f"new label tables: {[m.label_table_name for m in materials]}")
             if (
                 self.materialisation_strategy == "auto"
                 and self.check_min_data_requirement(connector, materials)
             ):
-                logger.info("Minimum data requirement satisfied.")
+                logger.get().info("Minimum data requirement satisfied.")
                 break
         if not self.check_min_data_requirement(connector, materials):
-            logger.warning(
+            logger.get().warning(
                 "Minimum data requirement not satisfied. Model performance may suffer. Try adding more datapoints by including more dates or increasing max_no_of_dates in the config."
             )
 
@@ -596,7 +596,7 @@ class ClassificationTrainer(MLTrainer):
             utils.plot_lift_chart(y_pred, y_true, lift_chart_file)
             connector.save_file(session, lift_chart_file, stage_name, overwrite=True)
         except Exception as e:
-            logger.error(f"Could not generate plots. {e}")
+            logger.get().error(f"Could not generate plots. {e}")
         pass
 
     def get_metrics(
@@ -786,7 +786,7 @@ class RegressionTrainer(MLTrainer):
             # connector.save_file(session, regression_chart_file, stage_name, overwrite=True)
 
         except Exception as e:
-            logger.error(f"Could not generate plots. {e}")
+            logger.get().error(f"Could not generate plots. {e}")
 
     def get_metrics(
         self, model, train_x, train_y, test_x, test_y, val_x, val_y, train_config

--- a/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
+++ b/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
@@ -423,8 +423,8 @@ class MLTrainer(ABC):
                     for date in [feature_date, label_date]:
                         whtService.run(feature_package_path, date)
             except Exception as e:
-                logger.get().warning(str(e))
-                logger.get().warning("Stopped generating new material dates.")
+                logger.get().error(str(e))
+                logger.get().error("Stopped generating new material dates.")
                 break
 
             logger.get().info(
@@ -447,7 +447,9 @@ class MLTrainer(ABC):
             logger.get().debug(
                 f"new feature tables: {[m.feature_table_name for m in materials]}"
             )
-            logger.get().debug(f"new label tables: {[m.label_table_name for m in materials]}")
+            logger.get().debug(
+                f"new label tables: {[m.label_table_name for m in materials]}"
+            )
             if (
                 self.materialisation_strategy == "auto"
                 and self.check_min_data_requirement(connector, materials)
@@ -455,7 +457,7 @@ class MLTrainer(ABC):
                 logger.get().info("Minimum data requirement satisfied.")
                 break
         if not self.check_min_data_requirement(connector, materials):
-            logger.get().warning(
+            logger.get().error(
                 "Minimum data requirement not satisfied. Model performance may suffer. Try adding more datapoints by including more dates or increasing max_no_of_dates in the config."
             )
 

--- a/src/predictions/profiles_mlcorelib/utils/S3Utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/S3Utils.py
@@ -45,7 +45,9 @@ class S3Utils:
                     s3_key = os.path.join(destination, subdir[len(path) + 1 :], file)
                     try:
                         client.upload_fileobj(data, bucket, s3_key)
-                        logger.get().debug(f"File {full_path} uploaded to {bucket}/{s3_key}")
+                        logger.get().debug(
+                            f"File {full_path} uploaded to {bucket}/{s3_key}"
+                        )
                     except FileNotFoundError:
                         raise Exception(
                             f"The file {full_path} was not found in ec2 while uploading trained files to s3."

--- a/src/predictions/profiles_mlcorelib/utils/S3Utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/S3Utils.py
@@ -12,7 +12,7 @@ class S3Utils:
         for obj in objects:
             key = obj["Key"]
             if key == s3_path:
-                logger.debug(f"Skipping object: key: {key}, s3_path: {s3_path}")
+                logger.get().debug(f"Skipping object: key: {key}, s3_path: {s3_path}")
                 continue
             local_file_path = os.path.join(
                 local_directory, os.path.relpath(key, s3_path)
@@ -20,8 +20,8 @@ class S3Utils:
             if not os.path.exists(os.path.dirname(local_file_path)):
                 os.makedirs(os.path.dirname(local_file_path))
             client.download_file(bucket_name, key, local_file_path)
-            logger.debug(f"File {key} downloaded to {local_file_path}")
-        logger.debug(
+            logger.get().debug(f"File {key} downloaded to {local_file_path}")
+        logger.get().debug(
             f"All files from {bucket_name}/{s3_path} downloaded to {local_directory}"
         )
 
@@ -30,9 +30,9 @@ class S3Utils:
         objects = s3.list_objects(Bucket=bucket_name, Prefix=folder_name)["Contents"]
         for obj in objects:
             s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
-            logger.debug(f"Deleted object: {obj['Key']}")
+            logger.get().debug(f"Deleted object: {obj['Key']}")
         s3.delete_object(Bucket=bucket_name, Key=folder_name)
-        logger.debug(f"Deleted folder: {folder_name}")
+        logger.get().debug(f"Deleted folder: {folder_name}")
 
     def upload_directory(bucket, aws_region_name, destination, path, allowedFiles):
         client = boto3.client("s3", region_name=aws_region_name)
@@ -45,7 +45,7 @@ class S3Utils:
                     s3_key = os.path.join(destination, subdir[len(path) + 1 :], file)
                     try:
                         client.upload_fileobj(data, bucket, s3_key)
-                        logger.debug(f"File {full_path} uploaded to {bucket}/{s3_key}")
+                        logger.get().debug(f"File {full_path} uploaded to {bucket}/{s3_key}")
                     except FileNotFoundError:
                         raise Exception(
                             f"The file {full_path} was not found in ec2 while uploading trained files to s3."

--- a/src/predictions/profiles_mlcorelib/utils/logger.py
+++ b/src/predictions/profiles_mlcorelib/utils/logger.py
@@ -1,28 +1,19 @@
 import logging
 
-class LoggerClass():
 
+class LoggerClass:
     def __init__(self):
         self._logger = self.default_logger()
 
     def default_logger(self):
-        # Define the logger with the desired name
         logger = logging.getLogger("churn_prediction")
-
-        # Configure the logger with the desired log level and handlers
         logger.setLevel(logging.DEBUG)
-
-        # file_handler = logging.FileHandler("classifier.log")
-        # file_handler.setLevel(logging.INFO)
-
         console_handler = logging.StreamHandler()
         console_handler.setLevel(logging.DEBUG)
-
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        # file_handler.setFormatter(formatter)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
         console_handler.setFormatter(formatter)
-
-        # logger.addHandler(file_handler)
         logger.addHandler(console_handler)
         return logger
 
@@ -32,4 +23,6 @@ class LoggerClass():
     def set_logger(self, newLogger):
         self._logger = newLogger
 
+
+# Don't use "warning" method of the logger since it is not impelmented by the pynative logger
 logger = LoggerClass()

--- a/src/predictions/profiles_mlcorelib/utils/logger.py
+++ b/src/predictions/profiles_mlcorelib/utils/logger.py
@@ -1,21 +1,35 @@
-# logger.py
 import logging
 
-# Define the logger with the desired name
-logger = logging.getLogger("churn_prediction")
+class LoggerClass():
 
-# Configure the logger with the desired log level and handlers
-logger.setLevel(logging.DEBUG)
+    def __init__(self):
+        self._logger = self.default_logger()
 
-# file_handler = logging.FileHandler("classifier.log")
-# file_handler.setLevel(logging.INFO)
+    def default_logger(self):
+        # Define the logger with the desired name
+        logger = logging.getLogger("churn_prediction")
 
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.DEBUG)
+        # Configure the logger with the desired log level and handlers
+        logger.setLevel(logging.DEBUG)
 
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-# file_handler.setFormatter(formatter)
-console_handler.setFormatter(formatter)
+        # file_handler = logging.FileHandler("classifier.log")
+        # file_handler.setLevel(logging.INFO)
 
-# logger.addHandler(file_handler)
-logger.addHandler(console_handler)
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.DEBUG)
+
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        # file_handler.setFormatter(formatter)
+        console_handler.setFormatter(formatter)
+
+        # logger.addHandler(file_handler)
+        logger.addHandler(console_handler)
+        return logger
+
+    def get(self):
+        return self._logger
+
+    def set_logger(self, newLogger):
+        self._logger = newLogger
+
+logger = LoggerClass()

--- a/src/predictions/profiles_mlcorelib/utils/utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/utils.py
@@ -372,7 +372,9 @@ def convert_ts_str_to_dt_str(timestamp_str: str) -> str:
         string_date = timestamp.strftime(constants.MATERIAL_DATE_FORMAT)
         return string_date
     except Exception as e:
-        logger.get().error(f"Error occurred while converting timestamp to date string: {e}")
+        logger.get().error(
+            f"Error occurred while converting timestamp to date string: {e}"
+        )
         raise Exception(
             f"Error occurred while converting timestamp to date string: {e}"
         )
@@ -435,7 +437,9 @@ def delete_folder(folder_path: str) -> None:
     except FileNotFoundError:
         logger.get().error(f"Error: Folder '{folder_path}' not found.")
     except PermissionError:
-        logger.get().error(f"Error: Permission denied. Unable to delete '{folder_path}'.")
+        logger.get().error(
+            f"Error: Permission denied. Unable to delete '{folder_path}'."
+        )
     except OSError as e:
         logger.get().error(f"Error occurred while deleting folder '{folder_path}': {e}")
 
@@ -497,7 +501,7 @@ def datetime_to_date_string(datetime_str: str) -> str:
         # to match datetime string with given format
         # In this case datetime sting is in "%Y-%m-%d" format
         # and returning empty string
-        logger.get().warning(
+        logger.get().error(
             f"Not able to extract date string from datetime string {datetime_str}"
         )
         return ""
@@ -532,7 +536,7 @@ def generate_new_training_dates(
             break
 
     if not found:
-        logger.get().warning(
+        logger.get().error(
             "Couldn't find a date honouring proximity check. "
             f"Proceeding with {generated_feature_date} as feature_date"
         )
@@ -752,7 +756,7 @@ def plot_top_k_feature_importance(
     try:
         shap_values = shap.TreeExplainer(pipe["model"]).shap_values(train_x_processed)
     except Exception as e:
-        logger.get().warning(
+        logger.get().error(
             f"Exception occured while calculating shap values {e}, using KernelExplainer"
         )
         return

--- a/src/predictions/profiles_mlcorelib/utils/utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/utils.py
@@ -372,7 +372,7 @@ def convert_ts_str_to_dt_str(timestamp_str: str) -> str:
         string_date = timestamp.strftime(constants.MATERIAL_DATE_FORMAT)
         return string_date
     except Exception as e:
-        logger.error(f"Error occurred while converting timestamp to date string: {e}")
+        logger.get().error(f"Error occurred while converting timestamp to date string: {e}")
         raise Exception(
             f"Error occurred while converting timestamp to date string: {e}"
         )
@@ -419,25 +419,25 @@ def get_output_directory(folder_path: str) -> str:
 def delete_file(file_path: str) -> None:
     try:
         os.remove(file_path)
-        logger.info(f"File '{file_path}' deleted successfully from local.")
+        logger.get().info(f"File '{file_path}' deleted successfully from local.")
     except FileNotFoundError:
-        logger.error(f"Error: File '{file_path}' not found.")
+        logger.get().error(f"Error: File '{file_path}' not found.")
     except PermissionError:
-        logger.error(f"Error: Permission denied. Unable to delete '{file_path}'.")
+        logger.get().error(f"Error: Permission denied. Unable to delete '{file_path}'.")
     except OSError as e:
-        logger.error(f"Error occurred while deleting file '{file_path}': {e}")
+        logger.get().error(f"Error occurred while deleting file '{file_path}': {e}")
 
 
 def delete_folder(folder_path: str) -> None:
     try:
         shutil.rmtree(folder_path)
-        logger.info(f"Folder '{folder_path}' deleted successfully from local.")
+        logger.get().info(f"Folder '{folder_path}' deleted successfully from local.")
     except FileNotFoundError:
-        logger.error(f"Error: Folder '{folder_path}' not found.")
+        logger.get().error(f"Error: Folder '{folder_path}' not found.")
     except PermissionError:
-        logger.error(f"Error: Permission denied. Unable to delete '{folder_path}'.")
+        logger.get().error(f"Error: Permission denied. Unable to delete '{folder_path}'.")
     except OSError as e:
-        logger.error(f"Error occurred while deleting folder '{folder_path}': {e}")
+        logger.get().error(f"Error occurred while deleting folder '{folder_path}': {e}")
 
 
 def get_date_range(creation_ts: datetime, prediction_horizon_days: int) -> Tuple:
@@ -497,7 +497,7 @@ def datetime_to_date_string(datetime_str: str) -> str:
         # to match datetime string with given format
         # In this case datetime sting is in "%Y-%m-%d" format
         # and returning empty string
-        logger.warning(
+        logger.get().warning(
             f"Not able to extract date string from datetime string {datetime_str}"
         )
         return ""
@@ -532,7 +532,7 @@ def generate_new_training_dates(
             break
 
     if not found:
-        logger.warning(
+        logger.get().warning(
             "Couldn't find a date honouring proximity check. "
             f"Proceeding with {generated_feature_date} as feature_date"
         )
@@ -570,8 +570,8 @@ def subprocess_run(args):
             f"Error occurred while running subprocess with params {args}: {e}"
         )
     if response.returncode != 0:
-        logger.error(f"Error occurred. Exit code:{response.returncode}")
-        logger.debug(f"Subprocess Output: {response.stdout}")
+        logger.get().error(f"Error occurred. Exit code:{response.returncode}")
+        logger.get().debug(f"Subprocess Output: {response.stdout}")
         raise Exception(f"Subprocess Error: {response.stderr}")
     return response
 
@@ -752,14 +752,14 @@ def plot_top_k_feature_importance(
     try:
         shap_values = shap.TreeExplainer(pipe["model"]).shap_values(train_x_processed)
     except Exception as e:
-        logger.warning(
+        logger.get().warning(
             f"Exception occured while calculating shap values {e}, using KernelExplainer"
         )
         return
 
     x_label = "Importance scores"
     if isinstance(shap_values, list):
-        logger.debug(
+        logger.get().debug(
             "Got List output, suggesting that the model is a multi-output model. \
                 Using the second output for plotting feature importance"
         )
@@ -770,7 +770,7 @@ def plot_top_k_feature_importance(
         and len(shap_values.shape) == 3
         and shap_values.shape[2] == 2
     ):
-        logger.debug(
+        logger.get().debug(
             "Got 3D numpy array with last dimension having depth of 2. Taking the second output for plotting feature importance"
         )
         shap_values = shap_values[:, :, 1]

--- a/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
@@ -147,7 +147,7 @@ class PythonWHT:
 
             return True
         except AssertionError as e:
-            logger.debug(
+            logger.get().debug(
                 f"{e}. Skipping the sequence tuple {feature_material_seq_no, label_material_seq_no} as it is not valid"
             )
             return False
@@ -300,7 +300,7 @@ class PythonWHT:
                 self.run(feature_package_path, date)
 
         if not materialise_data:
-            logger.warning(
+            logger.get().warning(
                 "Failed to materialise feature and label data. Will attempt to fetch materialised data from warehouse registry table"
             )
 
@@ -312,7 +312,7 @@ class PythonWHT:
             "project_folder": self.project_folder_path,
         }
         self._getPB().run(args)
-        logger.info(f"Materialised data successfully, for date {date}")
+        logger.get().info(f"Materialised data successfully, for date {date}")
 
     def _get_valid_feature_label_dates(
         self,
@@ -360,7 +360,7 @@ class PythonWHT:
                 feature_date = utils.date_add(start_date, prediction_horizon_days)
                 label_date = utils.date_add(feature_date, prediction_horizon_days)
             else:
-                logger.exception(
+                logger.get().exception(
                     f"We don't need to fetch feature_date and label_date to materialise new datasets because Tables {material_info.feature_table_name} and {material_info.label_table_name} already exist. Please check generated materials for discrepancies."
                 )
                 raise Exception(
@@ -457,7 +457,7 @@ class PythonWHT:
             ]
             return complete_sequences
 
-        logger.info("getting material names")
+        logger.get().info("getting material names")
         (materials) = self._get_material_names(
             start_date,
             end_date,

--- a/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
@@ -300,7 +300,7 @@ class PythonWHT:
                 self.run(feature_package_path, date)
 
         if not materialise_data:
-            logger.get().warning(
+            logger.get().error(
                 "Failed to materialise feature and label data. Will attempt to fetch materialised data from warehouse registry table"
             )
 

--- a/src/predictions/profiles_mlcorelib/wht/rudderPB.py
+++ b/src/predictions/profiles_mlcorelib/wht/rudderPB.py
@@ -20,12 +20,12 @@ class RudderPB:
             "-c",
             arg["site_config_path"],
         ]
-        logger.info(
+        logger.get().info(
             f"Fetching latest model hash by running command: {' '.join(pb_args)}"
         )
         pb_compile_output_response = utils.subprocess_run(pb_args)
         pb_compile_output = (pb_compile_output_response.stdout).lower()
-        logger.info(f"pb compile output: {pb_compile_output}")
+        logger.get().info(f"pb compile output: {pb_compile_output}")
         return pb_compile_output
 
     def run(self, arg: dict):
@@ -47,7 +47,7 @@ class RudderPB:
             "-c",
             arg["site_config_path"],
         ]
-        logger.info(
+        logger.get().info(
             f"Materialising historic data for {arg['features_valid_time']} using pb: {' '.join(pb_args)} "
         )
         try:
@@ -69,7 +69,7 @@ class RudderPB:
             "-c",
             arg["site_config_path"],
         ]
-        logger.info(f"Fetching all models by running command: {' '.join(pb_args)}")
+        logger.get().info(f"Fetching all models by running command: {' '.join(pb_args)}")
 
         try:
             pb_show_models_response = utils.subprocess_run(pb_args)
@@ -97,7 +97,7 @@ class RudderPB:
             try:
                 return json.loads(json_string)
             except json.JSONDecodeError as e:
-                logger.debug(f"error while decoding json {json_string}; error {e}")
+                logger.get().debug(f"error while decoding json {json_string}; error {e}")
                 end_index = end_index - 1
 
     def get_latest_material_hash(

--- a/src/predictions/profiles_mlcorelib/wht/rudderPB.py
+++ b/src/predictions/profiles_mlcorelib/wht/rudderPB.py
@@ -69,7 +69,9 @@ class RudderPB:
             "-c",
             arg["site_config_path"],
         ]
-        logger.get().info(f"Fetching all models by running command: {' '.join(pb_args)}")
+        logger.get().info(
+            f"Fetching all models by running command: {' '.join(pb_args)}"
+        )
 
         try:
             pb_show_models_response = utils.subprocess_run(pb_args)
@@ -97,7 +99,9 @@ class RudderPB:
             try:
                 return json.loads(json_string)
             except json.JSONDecodeError as e:
-                logger.get().debug(f"error while decoding json {json_string}; error {e}")
+                logger.get().debug(
+                    f"error while decoding json {json_string}; error {e}"
+                )
                 end_index = end_index - 1
 
     def get_latest_material_hash(


### PR DESCRIPTION
## Description of the change

The logger which is being used in the predictions code doesn't work in the pynative flow since n python subprocess gets created. To make it work instead of getting the default logger at import time, now the code is getting the value at run time using the `.get()` method

- The logger class has a `set_logger` method which is being used by pynative training and prediction classes so that the code can start using the pynative logger
- Since the pynative logger doesn't have a `warning` method and `warn` method in python logger is deprecated. So replaced `warning` with `error` call
- Pynative logger can't be imported in snowflake stored procedure so using print statement there

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
