### PR TITLE
chore: make pb 0.14.1 the min version for 0.3.0 release

### DIFF
--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -13,7 +13,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     install_requires=[
-        "profiles_rudderstack>=0.14.2",
+        "profiles_rudderstack>=0.14.1",
         "cachetools>=5.3.2",
         "hyperopt>=0.2.7",
         "joblib>=1.3.2",

--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -13,7 +13,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     install_requires=[
-        "profiles_rudderstack>=0.12.0",
+        "profiles_rudderstack>=0.14.2",
         "cachetools>=5.3.2",
         "hyperopt>=0.2.7",
         "joblib>=1.3.2",


### PR DESCRIPTION
## Description of the change

0.14.0 - Pywht fix for prediction model able to access Training output
0.14.1 - wht fix for certain BQ projects not working

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
