### PR TITLE
appending values on training_metrics

### DIFF
--- a/src/predictions/profiles_mlcorelib/connectors/wh/bigquery_base_connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/wh/bigquery_base_connector.py
@@ -37,7 +37,7 @@ class BigqueryConnector(ConnectorBase):
                 df,
                 destination_table_path,
                 project_id=self.db_config["project_id"],
-                if_exists="replace",
+                if_exists="append",
                 credentials=self.bq_credentials,
             )
 


### PR DESCRIPTION
## Description of the change

> Appending values on training metrics. Ticket [link](https://linear.app/rudderstack/issue/PRML-590/bug-training-metrics-v4-table-getting-replaced-in-bigquery).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
