### PR TITLE
feat: skip training if valid file is present from previous runs

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from profiles_rudderstack.model import BaseModelType
 from profiles_rudderstack.recipe import PyNativeRecipe
 from profiles_rudderstack.material import WhtMaterial
@@ -16,6 +17,8 @@ from ..utils import constants
 
 from ..wht.pyNativeWHT import PyNativeWHT
 from ..train import _train
+from datetime import datetime, timedelta
+import pandas as pd
 
 
 class TrainingModel(BaseModelType):
@@ -27,7 +30,8 @@ class TrainingModel(BaseModelType):
             "occurred_at_col": {"type": "string"},
             **EntityKeyBuildSpecSchema["properties"],
             **MaterializationBuildSpecSchema["properties"],
-            "validity_time": {"type": "string"},
+            "training_file_lookup_path": {"type": "string"},
+            "validity_time": {"type": "string", "enum": ["day", "week"]},
             "inputs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
             "ml_config": {
                 "type": "object",
@@ -88,6 +92,54 @@ class TrainingRecipe(PyNativeRecipe):
             ".txt",
         )
 
+    def _skip_training(self, this: WhtMaterial):
+        if not self.build_spec.get("validity_time"):
+            return False
+        validity_time = self.build_spec.get("validity_time")
+        if self.build_spec.get("training_file_lookup_path"):
+            mat_name_without_seq = this.name().rsplit("_", 1)[0]
+            lookup_path = self.build_spec.get("training_file_lookup_path")
+            if not os.path.exists(lookup_path):
+                raise Exception(f"Path {lookup_path} does not exist")
+            for root, dirs, _ in os.walk(lookup_path):
+                for subdir in dirs:
+                    if mat_name_without_seq in subdir:
+                        subdir_path = os.path.join(root, subdir)
+                        creation_time = os.path.getctime(subdir_path)
+                        creation_datetime = datetime.fromtimestamp(creation_time)
+                        time_delta = {
+                            "day": timedelta(days=1),
+                            "week": timedelta(weeks=1),
+                        }
+                        if (
+                            creation_datetime
+                            >= datetime.now() - time_delta[validity_time]
+                        ):
+                            subdir_files = [
+                                f
+                                for f in os.listdir(subdir_path)
+                                if os.path.isfile(os.path.join(subdir_path, f))
+                            ]
+                            if len(subdir_files) == 0:
+                                # Run probably failed that is why no files are present
+                                continue
+                            dest_dir = os.path.join(
+                                this.get_output_folder(), this.name()
+                            )
+                            os.makedirs(dest_dir, exist_ok=True)
+                            for file in os.listdir(subdir_path):
+                                src_path = os.path.join(subdir_path, file)
+                                dst_path = os.path.join(dest_dir, file)
+                                if os.path.isdir(src_path):
+                                    shutil.copytree(src_path, dst_path)
+                                else:
+                                    shutil.copy2(src_path, dst_path)
+                            self.logger.info(
+                                f"Valid training file found for {this.name()} in {subdir_path}"
+                            )
+                            return True
+        return False
+
     def register_dependencies(self, this: WhtMaterial):
         for input in self.build_spec["inputs"]:
             this.de_ref(input)
@@ -97,6 +149,13 @@ class TrainingRecipe(PyNativeRecipe):
         return f"{folder}/{this.name()}/training_file"
 
     def execute(self, this: WhtMaterial):
+        if self._skip_training(this):
+            self.logger.info(f"Skipping training")
+            # pb expects every model to create a material
+            data = {"dummy_column": ["dummy_value"]}
+            df = pd.DataFrame(data)
+            this.write_output(df)
+            return
         logger.set_logger(self.logger)
         whtService = PyNativeWHT(this)
         site_config_path = this.wht_ctx.site_config().get("FilePath")

--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -31,7 +31,7 @@ class TrainingModel(BaseModelType):
             **EntityKeyBuildSpecSchema["properties"],
             **MaterializationBuildSpecSchema["properties"],
             "training_file_lookup_path": {"type": "string"},
-            "validity_time": {"type": "string", "enum": ["day", "week"]},
+            "validity_time": {"type": "string", "enum": ["day", "week", "month"]},
             "inputs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
             "ml_config": {
                 "type": "object",
@@ -110,6 +110,7 @@ class TrainingRecipe(PyNativeRecipe):
                         time_delta = {
                             "day": timedelta(days=1),
                             "week": timedelta(weeks=1),
+                            "month": timedelta(days=30),
                         }
                         if (
                             creation_datetime


### PR DESCRIPTION
## Description of the change

This PR adds support for skipping training model if it finds a valid training file from previous run. If found, it copies the directory to the current output folder so that the prediction model can use it without worrying about whether training was skipped or not. A dummy table is also created in the warehouse since pb requires it.

To implement this, added support for 2 new fields in the yaml - `training_file_lookup_path` and `validity_time`

`validity_time` - Specifies how old training outputs can be used
`training_file_lookup_path` - The directory in which model should search for the training files

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
