### PR TITLE
feat: skip training in UI if valid file is present from previous runs

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -13,11 +13,12 @@ from ..utils.logger import logger
 
 from .warehouse import standardize_ref_name
 
-from ..utils import constants
+from ..utils import constants, utils
+from ..utils.S3Utils import S3Utils
 
 from ..wht.pyNativeWHT import PyNativeWHT
 from ..train import _train
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import pandas as pd
 
 
@@ -95,9 +96,28 @@ class TrainingRecipe(PyNativeRecipe):
     def _skip_training(self, this: WhtMaterial):
         if not self.build_spec.get("validity_time"):
             return False
-        validity_time = self.build_spec.get("validity_time")
+        site_config_path = this.wht_ctx.site_config().get("FilePath")
+        py_models = utils.load_yaml(site_config_path)["py_models"]
+        mat_name_without_seq = this.name().rsplit("_", 1)[0]
+        if "credentials_presets" in py_models:
+            # This flow is for runs in the UI
+            credentials_presets = py_models["credentials_presets"]
+            if "run_artefacts_s3" in credentials_presets:
+                run_artefacts_config = credentials_presets["run_artefacts_s3"]
+                bucket = run_artefacts_config["bucket"]
+                region = run_artefacts_config["region"]
+                path = run_artefacts_config["path"]
+                self.logger.info(f"Checking for training files in {bucket} at {path}")
+                return S3Utils.download_training_artifacts(
+                    bucket,
+                    region,
+                    path,
+                    os.path.join(this.get_output_folder(), this.name()),
+                    mat_name_without_seq,
+                    self._map_validity_to_timestamp(datetime.now(timezone.utc)),
+                )
+        # This flow is for runs from CLI
         if self.build_spec.get("training_file_lookup_path"):
-            mat_name_without_seq = this.name().rsplit("_", 1)[0]
             lookup_path = self.build_spec.get("training_file_lookup_path")
             if not os.path.exists(lookup_path):
                 raise Exception(f"Path {lookup_path} does not exist")
@@ -107,14 +127,8 @@ class TrainingRecipe(PyNativeRecipe):
                         subdir_path = os.path.join(root, subdir)
                         creation_time = os.path.getctime(subdir_path)
                         creation_datetime = datetime.fromtimestamp(creation_time)
-                        time_delta = {
-                            "day": timedelta(days=1),
-                            "week": timedelta(weeks=1),
-                            "month": timedelta(days=30),
-                        }
-                        if (
-                            creation_datetime
-                            >= datetime.now() - time_delta[validity_time]
+                        if creation_datetime >= self._map_validity_to_timestamp(
+                            datetime.now()
                         ):
                             subdir_files = [
                                 f
@@ -141,6 +155,15 @@ class TrainingRecipe(PyNativeRecipe):
                             return True
         return False
 
+    def _map_validity_to_timestamp(self, current_time):
+        validity_time = self.build_spec.get("validity_time")
+        time_delta = {
+            "day": timedelta(days=1),
+            "week": timedelta(weeks=1),
+            "month": timedelta(days=30),
+        }
+        return current_time - time_delta[validity_time]
+
     def register_dependencies(self, this: WhtMaterial):
         for input in self.build_spec["inputs"]:
             this.de_ref(input)
@@ -150,14 +173,14 @@ class TrainingRecipe(PyNativeRecipe):
         return f"{folder}/{this.name()}/training_file"
 
     def execute(self, this: WhtMaterial):
+        logger.set_logger(self.logger)
         if self._skip_training(this):
-            self.logger.info(f"Skipping training")
+            self.logger.info(f"Skipping training for {this.name()}")
             # pb expects every model to create a material
             data = {"dummy_column": ["dummy_value"]}
             df = pd.DataFrame(data)
             this.write_output(df)
             return
-        logger.set_logger(self.logger)
         whtService = PyNativeWHT(this)
         site_config_path = this.wht_ctx.site_config().get("FilePath")
         # TODO: Get creds from pywht

--- a/src/predictions/profiles_mlcorelib/utils/S3Utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/S3Utils.py
@@ -47,13 +47,13 @@ class S3Utils:
         response = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
         for obj in response.get("Contents", []):
             creation_time = obj["LastModified"]
-            isRecipeFile = folder_substring in os.path.basename(
+            is_recipe_file = folder_substring in os.path.basename(
                 obj["Key"]
             )  # To avoid downloading top level training recipe which is created by the describe function
             if (
                 creation_time > min_creation_time
                 and folder_substring in obj["Key"]
-                and not isRecipeFile
+                and not is_recipe_file
             ):
                 file_key = obj["Key"]
                 match = re.search(f"(.*?{re.escape(folder_substring)}[^/]*)", file_key)

--- a/src/predictions/profiles_mlcorelib/utils/S3Utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/S3Utils.py
@@ -1,6 +1,7 @@
 import os
 import boto3
 from ..utils.logger import logger
+import re
 
 
 class S3Utils:
@@ -33,6 +34,44 @@ class S3Utils:
             logger.get().debug(f"Deleted object: {obj['Key']}")
         s3.delete_object(Bucket=bucket_name, Key=folder_name)
         logger.get().debug(f"Deleted folder: {folder_name}")
+
+    def download_training_artifacts(
+        bucket_name,
+        region,
+        prefix,
+        download_directory,
+        folder_substring,
+        min_creation_time,
+    ):
+        s3 = boto3.client("s3", region_name=region)
+        response = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+        for obj in response.get("Contents", []):
+            creation_time = obj["LastModified"]
+            isRecipeFile = folder_substring in os.path.basename(
+                obj["Key"]
+            )  # To avoid downloading top level training recipe which is created by the describe function
+            if (
+                creation_time > min_creation_time
+                and folder_substring in obj["Key"]
+                and not isRecipeFile
+            ):
+                file_key = obj["Key"]
+                match = re.search(f"(.*?{re.escape(folder_substring)}[^/]*)", file_key)
+                if match:
+                    path_to_download = (
+                        match.group(1) + "/"
+                    )  # Adding trailing slash so that the download function ignores any top level file matching the prefix
+                    config = {
+                        "region": region,
+                        "bucket": bucket_name,
+                        "path": path_to_download,
+                    }
+                    logger.get().info(
+                        f"Downloading training artifacts from {path_to_download} to {download_directory}"
+                    )
+                    S3Utils.download_directory(config, download_directory)
+                    return True
+        return False
 
     def upload_directory(bucket, aws_region_name, destination, path, allowedFiles):
         client = boto3.client("s3", region_name=aws_region_name)


### PR DESCRIPTION
## Description of the change

When running the project from UI, the artefacts get uploaded on S3. Updated the training check method to check for files in S3 if the details are provided in site config

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
