### PR TITLE
removing start_date and end_date from configs

### DIFF
--- a/src/predictions/profiles_mlcorelib/config/model_configs.yaml
+++ b/src/predictions/profiles_mlcorelib/config/model_configs.yaml
@@ -8,10 +8,6 @@ data:
   task: classification # classification or regression; Can support a few other tasks in the future, like ltv, churn etc which can be super classes of classification/regression.
   index_timestamp: valid_at
   eligible_users: # Can add an sql where condition to filter users. Ex: is_active = 1 and lower(country) = 'us'
-  # train_start_dt: '2023-04-24'
-  train_start_dt: # The start and end dates can be left empty. If not, the model uses these dates to get historic data for training. 
-  # train_end_dt: '2023-05-01'
-  train_end_dt:
   prediction_horizon_days: 7 # Days in advance to predict the label_column. 
   user_preference_order_infra: 
     - local

--- a/src/predictions/profiles_mlcorelib/train.py
+++ b/src/predictions/profiles_mlcorelib/train.py
@@ -255,7 +255,7 @@ def _train(
         entity_var_model_name, model_hash, latest_seq_no
     )
 
-    start_date, end_date = utils.get_date_range(
+    start_date, end_date = whtService.get_date_range(
         creation_ts, trainer.prediction_horizon_days
     )
 

--- a/src/predictions/profiles_mlcorelib/train.py
+++ b/src/predictions/profiles_mlcorelib/train.py
@@ -255,12 +255,9 @@ def _train(
         entity_var_model_name, model_hash, latest_seq_no
     )
 
-    start_date, end_date = trainer.train_start_dt, trainer.train_end_dt
-
-    if start_date is None or end_date is None:
-        start_date, end_date = utils.get_date_range(
-            creation_ts, trainer.prediction_horizon_days
-        )
+    start_date, end_date = utils.get_date_range(
+        creation_ts, trainer.prediction_horizon_days
+    )
 
     absolute_input_models = whtService.get_input_models(inputs)
 

--- a/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
+++ b/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
@@ -49,8 +49,6 @@ class MLTrainer(ABC):
         self.output_profiles_ml_model = kwargs["data"]["output_profiles_ml_model"]
         self.index_timestamp = kwargs["data"]["index_timestamp"]
         self.eligible_users = kwargs["data"]["eligible_users"]
-        self.train_start_dt = kwargs["data"]["train_start_dt"]
-        self.train_end_dt = kwargs["data"]["train_end_dt"]
         self.prediction_horizon_days = kwargs["data"]["prediction_horizon_days"]
         self.max_row_count = kwargs["data"]["max_row_count"]
         self.recall_to_precision_importance = kwargs["data"][

--- a/src/predictions/profiles_mlcorelib/utils/utils.py
+++ b/src/predictions/profiles_mlcorelib/utils/utils.py
@@ -444,15 +444,6 @@ def delete_folder(folder_path: str) -> None:
         logger.get().error(f"Error occurred while deleting folder '{folder_path}': {e}")
 
 
-def get_date_range(creation_ts: datetime, prediction_horizon_days: int) -> Tuple:
-    start_date = creation_ts - timedelta(days=2 * prediction_horizon_days)
-    end_date = creation_ts - timedelta(days=prediction_horizon_days)
-    if isinstance(start_date, datetime):
-        start_date = start_date.date()
-        end_date = end_date.date()
-    return str(start_date), str(end_date)
-
-
 def date_add(reference_date: str, add_days: int) -> str:
     """
     Adds the horizon days to the reference date (in the format "YYYY-MM-DD") and

--- a/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 from typing import List, Tuple, Dict
 
 from ..utils import utils
@@ -21,6 +22,24 @@ class PyNativeWHT:
         project_folder_path: str,
     ) -> None:
         self.pythonWHT.init(connector, site_config_path, project_folder_path)
+
+    def get_date_range(
+        self, creation_ts: datetime, prediction_horizon_days: int
+    ) -> Tuple:
+        start_date, end_date = self.whtMaterial.wht_ctx.time_info()
+        if start_date is None and end_date is None:
+            start_date, end_date = self.pythonWHT.get_date_range(
+                creation_ts, prediction_horizon_days
+            )
+        elif end_date is None:
+            end_date = start_date + timedelta(days=prediction_horizon_days)
+        elif start_date is None:
+            start_date = end_date - timedelta(days=prediction_horizon_days)
+
+        if isinstance(start_date, datetime):
+            start_date = start_date.date()
+            end_date = end_date.date()
+        return str(start_date), str(end_date)
 
     def get_latest_entity_var_table(self, entity_key: str) -> Tuple[str, str, str]:
         model_ref = f"entity/{entity_key}/var_table"

--- a/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
@@ -44,11 +44,7 @@ class PyNativeWHT:
                 days=2 * prediction_horizon_days
             ):
                 raise Exception(
-                    f"begin_time and end_time needs to be atleast 2*prediction_horizon_days apart for the predictive feature."
-                )
-            else:
-                raise Exception(
-                    f"unconfigured scenario. Please define start_date and end_date properly."
+                    f"begin_time and end_time needs to be atleast {2*prediction_horizon_days} days apart for the predictive feature {self.whtMaterial.model.name()} with prediction_horizon_days: {prediction_horizon_days}"
                 )
 
         return str(start_date), str(end_date)

--- a/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 from typing import List, Dict, Optional, Sequence, Tuple
 
@@ -39,6 +39,16 @@ class PythonWHT:
         if mock:
             return MockPB()
         return RudderPB()
+
+    def get_date_range(
+        self, creation_ts: datetime, prediction_horizon_days: int
+    ) -> Tuple:
+        start_date = creation_ts - timedelta(days=2 * prediction_horizon_days)
+        end_date = creation_ts - timedelta(days=prediction_horizon_days)
+        if isinstance(start_date, datetime):
+            start_date = start_date.date()
+            end_date = end_date.date()
+        return str(start_date), str(end_date)
 
     def get_input_models(
         self,

--- a/tests/unit/MLTrainer.py
+++ b/tests/unit/MLTrainer.py
@@ -15,8 +15,6 @@ def build_trainer_config():
     config["data"]["entity_key"] = None
     config["data"]["output_profiles_ml_model"] = None
     config["data"]["index_timestamp"] = None
-    config["data"]["train_start_dt"] = None
-    config["data"]["train_end_dt"] = None
     config["data"]["eligible_users"] = None
     config["data"]["prediction_horizon_days"] = None
     config["data"]["inputs"] = None

--- a/tests/unit/pyNativeWHT.py
+++ b/tests/unit/pyNativeWHT.py
@@ -45,11 +45,15 @@ class TestPyNativeWHT(unittest.TestCase):
         self.pyNativeWHT.whtMaterial.wht_ctx.time_info = Mock(
             return_value=(begin_time, end_date)
         )
+
+        model_name = "prediction_model"
+        self.whtMaterial.model.name = Mock(return_value=model_name)
+
         with self.assertRaises(Exception) as context:
             _ = self.pyNativeWHT.get_date_range(creation_ts, prediction_horizon_days)
         self.assertIn(
             str(context.exception),
-            "begin_time and end_time needs to be atleast 2*prediction_horizon_days apart for the predictive feature.",
+            f"begin_time and end_time needs to be atleast {2*prediction_horizon_days} days apart for the predictive feature {self.whtMaterial.model.name()} with prediction_horizon_days: {prediction_horizon_days}",
         )
 
     def test_get_date_range_with_expected_value(self):


### PR DESCRIPTION
## Description of the change

> Ticket [link](https://linear.app/rudderstack/issue/PRML-796/remove-train-start-dt-and-train-end-dt-support-in-inputs).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
