### PR TITLE
creating selector sql using input_models

### DIFF
--- a/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
@@ -63,6 +63,9 @@ class BigQueryConnector(CommonWarehouseConnector):
         except Exception as e:
             raise Exception(f"Couldn't run the query: {query}. Error: {str(e)}")
 
+    def get_entity_var_table_ref(self, table_name: str) -> str:
+        return f"`{self.schema}`.`{table_name.capitalize()}`"
+
     def get_table_as_dataframe(
         self, _: google.cloud.bigquery.client.Client, table_name: str, **kwargs
     ) -> pd.DataFrame:

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -134,7 +134,10 @@ class Connector(ABC):
             column_lower = column.lower()
 
             for key, value in input_models.items():
-                if column_lower in key.lower() and value == "entity_var_item":
+                if (
+                    column_lower in key.lower()
+                    and value["model_type"] == "entity_var_item"
+                ):
                     raise Exception(
                         f"Array type features are not supported. Please remove '{column_lower}' and any other array type features from inputs."
                     )

--- a/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
@@ -61,11 +61,14 @@ class RedshiftConnector(CommonWarehouseConnector):
                 query_output = [Row(*row) for row in row_outputs]
                 return query_output
             else:
-                raise exception(
+                raise Exception(
                     "No result set is present for given query. Please check the query."
                 )
         else:
             return self.session.execute(query)
+
+    def get_entity_var_table_ref(self, table_name: str) -> str:
+        return f'"{self.schema}"."{table_name.lower()}"'
 
     def get_table_as_dataframe(
         self, _: redshift_connector.cursor.Cursor, table_name: str, **kwargs

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -57,6 +57,7 @@ class SnowflakeConnector(Connector):
         return
 
     def build_session(self, credentials: dict) -> snowflake.snowpark.Session:
+        self.schema = credentials.get("schema", None)
         self.connection_parameters = self.remap_credentials(credentials)
         session = Session.builder.configs(self.connection_parameters).create()
         return session
@@ -79,6 +80,9 @@ class SnowflakeConnector(Connector):
         del feature_table_df
 
         return self.session.call(*args)
+
+    def get_entity_var_table_ref(self, table_name: str) -> str:
+        return f'"{table_name.upper()}"'
 
     def get_merged_table(self, base_table, incoming_table):
         return (

--- a/src/predictions/profiles_mlcorelib/train.py
+++ b/src/predictions/profiles_mlcorelib/train.py
@@ -262,7 +262,7 @@ def _train(
             creation_ts, trainer.prediction_horizon_days
         )
 
-    absolute_input_models = whtService.get_input_models(inputs)
+    absolute_input_models = whtService.get_input_models(inputs, latest_entity_var_table)
 
     logger.get().info(
         f"Getting input column types from table: {latest_entity_var_table}"

--- a/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
@@ -68,8 +68,10 @@ class PyNativeWHT:
     def get_registry_table_name(self) -> str:
         return self.pythonWHT.get_registry_table_name()
 
-    def get_input_models(self, inputs: List[str]) -> Dict[str, str]:
-        return self.pythonWHT.get_input_models(inputs)
+    def get_input_models(
+        self, inputs: List[str], entity_var_table: str
+    ) -> Dict[str, Dict[str, str]]:
+        return self.pythonWHT.get_input_models(inputs, entity_var_table)
 
     def get_credentials(self, project_path: str, site_config_path: str) -> str:
         connection_name = utils.load_yaml(


### PR DESCRIPTION
## Description of the change

> Ticket [Link](https://linear.app/rudderstack/issue/PRML-806/remove-duplication-in-input-sql-queries-and-input-models). This is to deprecate the input_selector_sql being passed to train() through python model.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
