### PR TITLE
only joining while having entity_column in table

### DIFF
--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -899,7 +899,7 @@ class SnowflakeConnector(Connector):
             )
 
             temp_table = self.join_feature_table_label_table(
-                feature_table, label_table, entity_column, "inner"
+                feature_table.select(entity_column), label_table, entity_column, "inner"
             )
             final_feature_table = self.get_merged_table(final_feature_table, temp_table)
 


### PR DESCRIPTION
## Description of the change

> right now, both the tables have same columns, so, it creates ambiguous results after join.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
