### PR TITLE
fix: update the enable status key as per pb 0.16.0 changes

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -64,10 +64,12 @@ class TrainingModel(BaseModelType):
     def __init__(self, build_spec: dict, schema_version: int, pb_version: str) -> None:
         if (
             "materialization" not in build_spec
-            or "enable_status" not in build_spec["materialization"]
+            or "requested_enable_status" not in build_spec["materialization"]
         ):
             # This will ensure that the training model won't run if there is no prediction model in the project
-            build_spec["materialization"] = {"enable_status": "only_if_necessary"}
+            build_spec["materialization"] = {
+                "requested_enable_status": "only_if_necessary"
+            }
         super().__init__(build_spec, schema_version, pb_version)
 
     def get_material_recipe(self) -> PyNativeRecipe:

--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -13,7 +13,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     install_requires=[
-        "profiles_rudderstack>=0.14.1",
+        "profiles_rudderstack>=0.16.0",
         "cachetools>=5.3.2",
         "hyperopt>=0.2.7",
         "joblib>=1.3.2",


### PR DESCRIPTION
## Description of the change

In pb 0.16.0, the key was [renamed](https://github.com/rudderlabs/wht/pull/1569) from `enable_status` to `requested_enable_status`. This PR makes the same change in the training model for the logic to keep working in pb >= 0.16.0

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
