### PR TITLE
chore: add training validity in sample project

### DIFF
--- a/samples/py_native/models/profiles.yaml
+++ b/samples/py_native/models/profiles.yaml
@@ -4,6 +4,7 @@ models:
     model_spec:
       occurred_at_col: insert_ts
       entity_key: user
+      validity_time: day
       inputs:
         - packages/feature_table/entity/user/is_churned_7_days
         - packages/feature_table/entity/user/days_since_last_seen

--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -103,7 +103,7 @@ class TrainingRecipe(PyNativeRecipe):
         mat_name_without_seq = this.name().rsplit("_", 1)[0]
         if "credentials_presets" in py_models:
             # This flow is for runs in the UI
-            credentials_presets = py_models["credentials_presets"]
+            credentials_presets = py_models.get("credentials_presets", {})
             if "run_artefacts_s3" in credentials_presets:
                 run_artefacts_config = credentials_presets["run_artefacts_s3"]
                 bucket = run_artefacts_config["bucket"]

--- a/src/predictions/profiles_mlcorelib/py_native/training.py
+++ b/src/predictions/profiles_mlcorelib/py_native/training.py
@@ -103,8 +103,11 @@ class TrainingRecipe(PyNativeRecipe):
         mat_name_without_seq = this.name().rsplit("_", 1)[0]
         if "credentials_presets" in py_models:
             # This flow is for runs in the UI
-            credentials_presets = py_models.get("credentials_presets", {})
-            if "run_artefacts_s3" in credentials_presets:
+            credentials_presets = py_models["credentials_presets"]
+            if (
+                credentials_presets is not None
+                and "run_artefacts_s3" in credentials_presets
+            ):
                 run_artefacts_config = credentials_presets["run_artefacts_s3"]
                 bucket = run_artefacts_config["bucket"]
                 region = run_artefacts_config["region"]


### PR DESCRIPTION
## Description of the change

This field won't work in CI since `training_file_lookup_path` is missing and outputs are not shared across runs.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
