### PR TITLE
fix: add python version constraint

### DIFF
--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -5,6 +5,7 @@ setup(
     name="profiles_mlcorelib",
     version=version,
     author="rudderstack",
+    python_requires="<3.12",
     packages=find_packages(),
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
## Description of the change

`profiles_mlcorelib` doesn't support python3.12 because of `snowflake-snowpark-python` 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
