### PR TITLE
fetching type_hints from table directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ setuptools>=68.2.2
 # pyOpenSSL>=24.0.0
 # cryptography>=42.0.4
 pillow>=10.2.0
-pycaret==3.3.0
+pycaret==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ setuptools>=68.2.2
 # pyOpenSSL>=24.0.0
 # cryptography>=42.0.4
 pillow>=10.2.0
-pycaret==3.3.1
+pycaret==3.3.0

--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -893,7 +893,6 @@ class CommonWarehouseConnector(Connector):
     def generate_type_hint(
         self,
         df: pd.DataFrame,
-        column_types: Dict[str, List[str]],
     ):
         return None
 

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -468,7 +468,7 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def generate_type_hint(self, df: Any, column_types: Dict[str, List[str]]):
+    def generate_type_hint(self, df: Any):
         pass
 
     @abstractmethod

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -1078,17 +1078,11 @@ class SnowflakeConnector(Connector):
     def generate_type_hint(
         self,
         df: snowflake.snowpark.Table,
-        column_types: Dict[str, List[str]],
     ):
         types = []
-
-        for col in df.columns:
-            dtype_str = column_types[col]
-            for category, mapping in self.data_type_mapping.items():
-                if dtype_str in mapping:
-                    types.append(mapping[dtype_str])
-                    break
-
+        schema_fields = df.schema.fields
+        for field in schema_fields:
+            types.append(field.datatype)
         return types
 
     def call_prediction_udf(

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -1123,8 +1123,12 @@ class SnowflakeConnector(Connector):
         preds = preds.withColumn("columnindex", F.row_number().over(w))
         extracted_df = extracted_df.withColumn("columnindex", F.row_number().over(w))
         preds = preds.join(
-            extracted_df, preds.columnindex == extracted_df.columnindex, "inner"
-        ).drop("columnindex")
+            extracted_df,
+            preds.columnindex == extracted_df.columnindex,
+            "inner",
+            lsuffix="_left",
+            rsuffix="_right",
+        ).drop("columnindex_left", "columnindex_right")
 
         # Remove the dummy label column in case of Regression
         if "label" not in pred_output_df_columns:
@@ -1132,7 +1136,7 @@ class SnowflakeConnector(Connector):
 
         preds_with_percentile = preds.withColumn(
             percentile_column_name,
-            F.percent_rank().over(Window.orderBy(F.col(score_column_name))),
+            (F.percent_rank().over(Window.orderBy(F.col(score_column_name)))) * 100,
         )
 
         return preds_with_percentile

--- a/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
+++ b/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
@@ -123,9 +123,7 @@ def preprocess_and_predict(
     input_df = connector.select_relevant_columns(
         predict_data, required_features_upper_case
     )
-    types = connector.generate_type_hint(
-        input_df, results["column_names"]["feature_table_column_types"]
-    )
+    types = connector.generate_type_hint(input_df)
 
     predict_data = connector.add_index_timestamp_colum_for_predict_data(
         predict_data, trainer.index_timestamp, end_ts

--- a/tests/unit/SnowflakeConnector.py
+++ b/tests/unit/SnowflakeConnector.py
@@ -63,44 +63,6 @@ class TestLabelTable(unittest.TestCase):
         self.assertListEqual(actual_label_col_vals, expected_label_col_vals)
 
 
-class TestGenerateTypeHint(unittest.TestCase):
-    def setUp(self) -> None:
-        self.session = Session.builder.config("local_testing", True).create()
-        self.connector = MockSnowflakeConnector()
-
-    # Returns a list of type hints for given pandas DataFrame's fields
-    def test_returns_type_hints(self):
-        df = pd.DataFrame.from_dict(
-            {
-                "COL1": ["a", "b"],
-                "COL2": [1, 2],
-                "COL3": [1.1, 2.2],
-                "COL4": ["a1", "b1"],
-            }
-        )
-        table = self.session.create_dataframe(df)
-        column_types = {
-            "COL1": "StringType",
-            "COL2": "IntegerType",
-            "COL3": "FloatType",
-            "COL4": "StringType",
-        }
-
-        type_hints = self.connector.generate_type_hint(table, column_types)
-        self.assertEqual(
-            type_hints, [T.StringType(), T.IntegerType(), T.FloatType(), T.StringType()]
-        )
-
-    # Handles DataFrame with single row and column
-    def test_handles_single_row_and_column(self):
-        df = pd.DataFrame({"COL1": [1]})
-        table = self.session.create_dataframe(df)
-        column_types = {"COL1": "IntegerType"}
-
-        type_hints = self.connector.generate_type_hint(table, column_types)
-        self.assertEqual(type_hints, [T.IntegerType()])
-
-
 class TestSelectRelevantColumns(unittest.TestCase):
     def setUp(self) -> None:
         self.connector = MockSnowflakeConnector()


### PR DESCRIPTION
## Description of the change

> Ticket [link](https://linear.app/rudderstack/issue/PRML-860/fetch-data-types-from-var-table-during-predict-time-in-snowflake).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
