### PR TITLE
passing model name in training_summary json

### DIFF
--- a/src/predictions/profiles_mlcorelib/trainers/ClassificationTrainer.py
+++ b/src/predictions/profiles_mlcorelib/trainers/ClassificationTrainer.py
@@ -222,6 +222,7 @@ class ClassificationTrainer(MLTrainer):
         training_summary = {
             "timestamp": model_timestamp,
             "data": {
+                "model": model_results["model_class_name"],
                 "metrics": model_results["metrics"],
                 "threshold": model_results["prob_th"],
             },

--- a/src/predictions/profiles_mlcorelib/trainers/RegressionTrainer.py
+++ b/src/predictions/profiles_mlcorelib/trainers/RegressionTrainer.py
@@ -161,7 +161,10 @@ class RegressionTrainer(MLTrainer):
     ) -> dict:
         training_summary = {
             "timestamp": model_timestamp,
-            "data": {"metrics": model_results["metrics"]},
+            "data": {
+                "model": model_results["model_class_name"],
+                "metrics": model_results["metrics"],
+            },
         }
         return training_summary
 

--- a/tests/unit/MLTrainer.py
+++ b/tests/unit/MLTrainer.py
@@ -43,16 +43,26 @@ class TestClassificationTrainer(unittest.TestCase):
     def test_prepare_training_summary(self):
         config = build_trainer_config()
         trainer = TrainerFactory.create(config)
+        model_class_name = "MODEL_NAME"
         metrics = {"test": {}, "train": {}, "val": {}}
         timestamp = "2023-11-08"
         threshold = 0.62
         result = trainer.prepare_training_summary(
-            {"metrics": metrics, "prob_th": threshold}, timestamp
+            {
+                "model_class_name": model_class_name,
+                "metrics": metrics,
+                "prob_th": threshold,
+            },
+            timestamp,
         )
         self.assertEqual(
             result,
             {
-                "data": {"metrics": metrics, "threshold": threshold},
+                "data": {
+                    "model": model_class_name,
+                    "metrics": metrics,
+                    "threshold": threshold,
+                },
                 "timestamp": timestamp,
             },
         )
@@ -177,10 +187,19 @@ class TestRegressionTrainer(unittest.TestCase):
     def test_prepare_training_summary(self):
         config = build_trainer_config(task="regression")
         trainer = TrainerFactory.create(config)
+        model_class_name = "MODEL_NAME"
         metrics = {"test": {}, "train": {}, "val": {}}
         timestamp = "2023-11-08"
-        result = trainer.prepare_training_summary({"metrics": metrics}, timestamp)
-        self.assertEqual(result, {"data": {"metrics": metrics}, "timestamp": timestamp})
+        result = trainer.prepare_training_summary(
+            {"model_class_name": model_class_name, "metrics": metrics}, timestamp
+        )
+        self.assertEqual(
+            result,
+            {
+                "data": {"model": model_class_name, "metrics": metrics},
+                "timestamp": timestamp,
+            },
+        )
 
     def test_validate_data(self):
         config = build_trainer_config(task="regression")


### PR DESCRIPTION
## Description of the change

> Ticket [Link](https://linear.app/rudderstack/issue/PRML-484/change-the-output-metrics-structure-on-ui-to-support-pycaret-migration).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
