### PR TITLE
fix: move all training related keys under training in propensity YAML

### DIFF
--- a/samples/py_native/models/profiles.yaml
+++ b/samples/py_native/models/profiles.yaml
@@ -6,6 +6,11 @@ models:
       training:
         predict_var: packages/feature_table/entity/user/is_churned_7_days
         predict_window_days: 7
+        eligible_users: '*'
+        max_row_count: 500000
+        label_value: 1
+        type: classification
+        validity: day
       prediction:
         output_columns:
           percentile:
@@ -15,13 +20,7 @@ models:
             name: classification_churn_7_days
             description: description2
             is_feature: False
-      training_params:
         eligible_users: '*'
-        max_row_count: 500000
-        label_value: 1
-      type: classification
-      train_validity: day
-      prediction_eligible_users: '*'
       inputs:
         - packages/feature_table/entity/user/is_churned_7_days
         - packages/feature_table/entity/user/days_since_last_seen


### PR DESCRIPTION
## Description of the change

- Moved `training_params`, `type`, `training_validity` and `training_file_lookup_path` under `training` 
- Moved `prediction_eligible_users` under `prediction`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
