### PR TITLE
fix: remove mandatory fields from the default config

### DIFF
--- a/src/predictions/profiles_mlcorelib/config/model_configs.yaml
+++ b/src/predictions/profiles_mlcorelib/config/model_configs.yaml
@@ -1,6 +1,5 @@
 data:
   # Related to the data that is used to train the model
-  label_column: is_churned_7_days # Name of the entity_var that needs to be predicted in advance
   label_value: 1 # Value of the label_column when the entity does the event. Not required for regression tasks
   entity_column: user_main_id # Name of the entity defined in the profiles project. Ex: user_id, user_main_id, rudder_id etc
   entity_key: user # Name of the entity key defined in the profiles project. Ex: user, user_main, rudder etc
@@ -8,7 +7,6 @@ data:
   task: classification # classification or regression; Can support a few other tasks in the future, like ltv, churn etc which can be super classes of classification/regression.
   index_timestamp: valid_at
   eligible_users: # Can add an sql where condition to filter users. Ex: is_active = 1 and lower(country) = 'us'
-  prediction_horizon_days: 7 # Days in advance to predict the label_column. 
   user_preference_order_infra: 
     - local
     - rudderstack-infra


### PR DESCRIPTION
## Description of the change

Removed the 2 fields `label_column` and `prediction_horizon_days` since they are supposed to be provided by the customer.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
