### PR TITLE
refactor: infer touchpoint timestamp using wht internal methods

### DIFF
--- a/samples/attribution_project/models/profiles.yaml
+++ b/samples/attribution_project/models/profiles.yaml
@@ -25,7 +25,6 @@ models:
       conversion:
         touchpoints: # Defines the user journey sequence allowing us to evaluatel first, last and multi-touch models
           - from: inputs/rsMarketingPages
-            timestamp: timestamp
         conversion_vars: # What are the activities, outcomes, etc. that we actually want to measure. You can define more than 1. You can also define a value in addition to the count.
           - name: sf_order
             timestamp: user.Var('first_order_date')

--- a/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
@@ -531,7 +531,11 @@ class AttributionModelRecipe(PyNativeRecipe):
         )
 
     def _create_user_journey_cte(
-        self, material: WhtMaterial, user_journeys, entity_id_column_name, campaign_id_column_name
+        self,
+        material: WhtMaterial,
+        user_journeys,
+        entity_id_column_name,
+        campaign_id_column_name,
     ):
         # creating user journeys
         journey_query, union_op, set_jouney_ref = "", "", ""
@@ -541,7 +545,9 @@ class AttributionModelRecipe(PyNativeRecipe):
                 set_jouney_ref
                 + f"{prefix}{counter} = this.DeRef('{journey_info['from']}/var_table') "
             )
-            journey_info_timestamp = material.de_ref(journey_info["from"]).model.time_filtering_column()
+            journey_info_timestamp = material.de_ref(
+                journey_info["from"]
+            ).model.time_filtering_column()
             select_info = f"SELECT {entity_id_column_name}, {campaign_id_column_name}, {journey_info_timestamp} AS timestamp"
             from_info = f"FROM {{{{{prefix}{counter}}}}}"
             where_info = f"WHERE {campaign_id_column_name} is not NULL"
@@ -608,7 +614,10 @@ class AttributionModelRecipe(PyNativeRecipe):
             this.de_ref(dependency)
 
         journey_query, set_jouney_ref = self._create_user_journey_cte(
-            this, user_journeys, self.entity_id_column_name, self.campaign_id_column_name
+            this,
+            user_journeys,
+            self.entity_id_column_name,
+            self.campaign_id_column_name,
         )
         (
             daily_campaign_details_query,


### PR DESCRIPTION
## Description of the change

Till now we were asking the user to pass the `timestamp` field of the touchpoint models because the attribution model had no way to access the timestamp of the given model. This PR simplifies the YAML by removing the duplication due to the `timestamp` field. Instead the value is now being derived from the `time_filtering_column`

This is a BREAKING CHANGE since the model no more allows passing in a `timestamp` field

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
