### PR TITLE
feat: adapt python pb module to support pb stdout change

### DIFF
--- a/src/predictions/profiles_mlcorelib/wht/rudderPB.py
+++ b/src/predictions/profiles_mlcorelib/wht/rudderPB.py
@@ -84,7 +84,7 @@ class RudderPB:
     def extract_json_from_stdout(self, stdout):
         start_index = stdout.find("printing models")
         if start_index == -1:
-            return None
+            start_index = 0
 
         # Find the index of the first '{' after the line
         start_index = stdout.find("{", start_index)


### PR DESCRIPTION
## Description of the change

- Changes are being done on pb [side](https://linear.app/rudderstack/issue/FR-345/redirect-log-output-to-stderr-while-keeping-stdout-for-cli) which will change the exact logs which will python model will see when running `show models/compile`.
- Ran the python model with the corresponding pb build and made backward compatible changes

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
