### PR TITLE
selecting non-null, non-empty converted_date

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
@@ -688,7 +688,7 @@ class AttributionModelRecipe(PyNativeRecipe):
                 )
 
             from_info = f"FROM {{{{entity_var_table}}}}"
-            where_info = f"WHERE {conversion_info_column_name_timestamp} is not NULL"
+            where_info = f"WHERE {conversion_info_column_name_timestamp} is not NULL and {conversion_info_column_name_timestamp} != '' "
 
             conversion_query = f"""
                                 {select_info} 


### PR DESCRIPTION
## Description of the change

> Ticket [link](https://linear.app/rudderstack/issue/PRML-911/datediff-should-not-raise-errors-in-case-of-mismatched-data-types).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
