### PR TITLE
Revert "selecting non-null, non-empty converted_date"

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
@@ -688,7 +688,7 @@ class AttributionModelRecipe(PyNativeRecipe):
                 )
 
             from_info = f"FROM {{{{entity_var_table}}}}"
-            where_info = f"WHERE {conversion_info_column_name_timestamp} is not NULL and {conversion_info_column_name_timestamp} != '' "
+            where_info = f"WHERE {conversion_info_column_name_timestamp} is not NULL"
 
             conversion_query = f"""
                                 {select_info} 


### PR DESCRIPTION
Reverts rudderlabs/rudderstack-profiles-classifier#447

A timestamp datatype cannot be compared with empty string. It will throw an error. This is a breaking change which breaks well defined projects. 