### PR TITLE
chore: run propensity pynative tests only when model is updated

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,28 @@ jobs:
     - name: Run tests
       run: python -m unittest tests/unit/*.py
 
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      propensity: ${{ steps.filter.outputs.propensity }}
+    steps:
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          propensity:
+            - '!src/predictions/profiles_mlcorelib/py_native/attribution_report.py'
+            - '!src/predictions/profiles_mlcorelib/py_native/llm.py'
+        predicate-quantifier: every
+
   integration-test:
     runs-on: ubuntu-latest
-    needs: unit-test
+    needs:
+      - changes
+      - unit-test
+    if: ${{ needs.changes.outputs.propensity == 'true' }}
 
     strategy:
       matrix:


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
