### PR TITLE
fix: prediction model is causing error in feature view

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/prediction.py
+++ b/src/predictions/profiles_mlcorelib/py_native/prediction.py
@@ -63,8 +63,9 @@ class PredictionModel(BaseModelType):
     }
 
     def __init__(self, build_spec: dict, schema_version: int, pb_version: str) -> None:
+        entity_key = build_spec["entity_key"]
         build_spec["contract"] = {
-            "with_entity_ids": [build_spec["entity_key"]],
+            "with_entity_ids": [entity_key],
             "with_columns": [
                 {
                     "name": build_spec["ml_config"]["outputs"]["column_names"][
@@ -74,6 +75,14 @@ class PredictionModel(BaseModelType):
                 {"name": build_spec["ml_config"]["outputs"]["column_names"]["score"]},
             ],
         }
+        build_spec["ids"] = [
+            {
+                "select": entity_key
+                + "_main_id",  # FIXME: select should be computed from the entity object
+                "type": "rudder_id",
+                "entity": entity_key,
+            }
+        ]
         super().__init__(build_spec, schema_version, pb_version)
 
     def get_material_recipe(self) -> PyNativeRecipe:

--- a/src/predictions/profiles_mlcorelib/py_native/prediction.py
+++ b/src/predictions/profiles_mlcorelib/py_native/prediction.py
@@ -75,14 +75,15 @@ class PredictionModel(BaseModelType):
                 {"name": build_spec["ml_config"]["outputs"]["column_names"]["score"]},
             ],
         }
-        build_spec["ids"] = [
-            {
-                "select": entity_key
-                + "_main_id",  # FIXME: select should be computed from the entity object
-                "type": "rudder_id",
-                "entity": entity_key,
-            }
-        ]
+        if "ids" not in build_spec:
+            build_spec["ids"] = [
+                {
+                    "select": entity_key
+                    + "_main_id",  # FIXME: select should be computed from the entity object
+                    "type": "rudder_id",
+                    "entity": entity_key,
+                }
+            ]
         super().__init__(build_spec, schema_version, pb_version)
 
     def get_material_recipe(self) -> PyNativeRecipe:

--- a/src/predictions/profiles_mlcorelib/py_native/prediction.py
+++ b/src/predictions/profiles_mlcorelib/py_native/prediction.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from profiles_rudderstack.schema import (
     EntityKeyBuildSpecSchema,
     FeatureDetailsBuildSpecSchema,
+    EntityIdsBuildSpecSchema,
 )
 
 from .warehouse import standardize_ref_name
@@ -28,6 +29,7 @@ class PredictionModel(BaseModelType):
             "occurred_at_col": {"type": "string"},
             **EntityKeyBuildSpecSchema["properties"],
             **FeatureDetailsBuildSpecSchema["properties"],
+            **EntityIdsBuildSpecSchema["properties"],
             "inputs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
             "training_model": {"type": "string"},
             "ml_config": {

--- a/src/predictions/profiles_mlcorelib/py_native/propensity.py
+++ b/src/predictions/profiles_mlcorelib/py_native/propensity.py
@@ -4,6 +4,7 @@ from profiles_rudderstack.material import WhtFolder
 from typing import Tuple
 from profiles_rudderstack.schema import (
     EntityKeyBuildSpecSchema,
+    EntityIdsBuildSpecSchema,
 )
 
 PredictionColumnSpecSchema = {
@@ -24,6 +25,7 @@ class PropensityModel(BaseModelType):
         "additionalProperties": False,
         "properties": {
             **EntityKeyBuildSpecSchema["properties"],
+            **EntityIdsBuildSpecSchema["properties"],
             "inputs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
             "training": {
                 "type": "object",
@@ -163,7 +165,7 @@ class PropensityModel(BaseModelType):
                 )
         if self.build_spec["prediction"].get("eligible_users", None) is not None:
             data["eligible_users"] = self.build_spec["prediction"]["eligible_users"]
-        return {
+        spec = {
             "entity_key": self.build_spec["entity_key"],
             "training_model": training_model_ref,
             "inputs": self.build_spec["inputs"],
@@ -178,6 +180,9 @@ class PropensityModel(BaseModelType):
             },
             "features": features,
         }
+        if "ids" in self.build_spec:
+            spec["ids"] = self.build_spec["ids"]
+        return spec
 
     def get_material_recipe(self) -> PyNativeRecipe:
         return NoOpRecipe()


### PR DESCRIPTION
## Description of the change

**BUG** - Feature view expects all the feature-models to have ids defined. But in the case of prediction model, the ids were missing

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
