### PR TITLE
Added support for encrypted key-pair authentication on snowflake

### DIFF
--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -90,7 +90,7 @@ class SnowflakeConnector(Connector):
             self.connection_parameters["private_key"] = private_key
         session = Session.builder.configs(self.connection_parameters).create()
         # Removing the private key to prevent serialisation error in the snowflake stored procedure
-        _ = self.connection_parameters.pop("private_key")
+        _ = self.connection_parameters.pop("private_key", None)
         return session
 
     def join_file_path(self, file_name: str) -> str:

--- a/src/predictions/profiles_mlcorelib/utils/constants.py
+++ b/src/predictions/profiles_mlcorelib/utils/constants.py
@@ -83,6 +83,7 @@ SNOWFLAKE_TRAINING_PACKAGES = [
     "seaborn==0.12.0",
     "scikit-plot==0.3.7",
     "pycaret<=3.3.0",
+    "cryptography==42.0.2",
 ]
 
 

--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -39,7 +39,7 @@ setup(
         "pycaret==3.3.1",
         "boto3>=1.34.153",
         "google-auth-oauthlib>=1.0.0",
-        "cryptography>=42.0.4",
+        "cryptography>=42.0.2",
     ],
     include_package_data=True,
 )

--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -39,6 +39,7 @@ setup(
         "pycaret==3.3.1",
         "boto3>=1.34.153",
         "google-auth-oauthlib>=1.0.0",
+        "cryptography>=42.0.4",
     ],
     include_package_data=True,
 )

--- a/tests/unit/pythonWHT.py
+++ b/tests/unit/pythonWHT.py
@@ -77,7 +77,6 @@ class TestFetchValidHistoricMaterials(unittest.TestCase):
         self.assertEqual(len(materials), 1)
 
     def test_missing_sequence_number(self):
-
         self.pythonWHT.connector.check_table_entry_in_material_registry = Mock(
             return_value=True
         )


### PR DESCRIPTION
Current repo should support non encrypted p8 file too, but pywht needs a fix in sending that

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
