### PR TITLE
fix: propensity models in package project not working

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/propensity.py
+++ b/src/predictions/profiles_mlcorelib/py_native/propensity.py
@@ -101,7 +101,9 @@ class PropensityModel(BaseModelType):
         parent_folder.add_child_specs(
             training_model_name, "training_model", training_spec
         )
-        training_model_ref = parent_folder.folder_ref() + training_model_name
+        # Fixme: Uncomment the following line once pb is released with the rpc method
+        # training_model_ref = parent_folder.folder_ref_from_level_root() + training_model_name
+        training_model_ref = "models/" + training_model_name
         prediction_spec = self._get_prediction_spec(training_model_ref, training_spec)
         parent_folder.add_child_specs(
             model_name + "_prediction",


### PR DESCRIPTION
## Description of the change

**BUG** `folder_ref` method returns `packages/<package_name>/models` which throws error when trying to deRef training model `packages/<package_name>/models/training_model` from the prediction model.

**FIX** - Use a different method which returns ref as `models` without any package path

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
