### PR TITLE
Disabled logging for pycaret setup and added n_jobs = 1 so it is hono…

### DIFF
--- a/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
+++ b/src/predictions/profiles_mlcorelib/trainers/MLTrainer.py
@@ -237,6 +237,10 @@ class MLTrainer(ABC):
             categorical_features=categorical_cols,
             fold=n_folds,
             fold_strategy=fold_strategy,
+            system_log=False,
+            verbose=False,
+            html=False,
+            n_jobs=1,
         )
 
         for custom_metric in custom_metrics:
@@ -251,7 +255,11 @@ class MLTrainer(ABC):
             sort=metric_to_optimize, include=models_to_include
         )
         tuned_model = pycaret_tune_model(
-            best_model, optimize=metric_to_optimize, return_train_score=True
+            best_model,
+            optimize=metric_to_optimize,
+            return_train_score=True,
+            verbose=False,
+            tuner_verbose=False,
         )
 
         model_class_name = tuned_model.__class__.__name__


### PR DESCRIPTION
…red in parallel execution of tune_model

## Description of the change

Currently pycaret tries to write to log file in root directory and it fails when it doesnt get write access. fixed the issue by disabling logging, and making n_jobs = 1 so tune_model doesn't spawn more processes without this context (a limitation in pycaret)

A customer reported this issue on their snowflake. I couldn't replicate the failure in our snowflake, but could see that on our snowflake instance, it does try to write to a log file on root directory, and that gets gracefully handled. I could replicate the failure locally though, making the `logs.log` file read only. Even if i disable logging in setup() method, it still tries to log to the same file in tune_models in the parallel processing step (the setup config is not getting honored by tune_model). Only solution I could find was to disable parallel processing, by giving n_jobs = 1 in setup. this doesn't create new parallel jobs with default configs. 

> Description here

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
