### PR TITLE
fix: attribution model error when entity main id columns are present as model ids

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
@@ -630,7 +630,7 @@ class AttributionModelRecipe(PyNativeRecipe):
             tbl = obj["from"]
             column = this.de_ref(tbl).model.time_filtering_column()
             if not column:
-                raise Exception(f"occurred_at_col column not found in {tbl}")
+                raise Exception(f"occurred_at_col field not found in {tbl} yaml")
             self.inputs.update(
                 (
                     tbl,

--- a/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
@@ -630,7 +630,7 @@ class AttributionModelRecipe(PyNativeRecipe):
             tbl = obj["from"]
             column = this.de_ref(tbl).model.time_filtering_column()
             if not column:
-                raise Exception(f"Occurred at column not found in {tbl}")
+                raise Exception(f"occurred_at_col column not found in {tbl}")
             self.inputs.update(
                 (
                     tbl,


### PR DESCRIPTION
## Description of the change

- Tested the attribution model by replacing `inputs/rsMarketingPages` with `rs_marketing_pages_sql`
- Added a new validation for timestamp column

```
- name: rs_marketing_pages_sql
    model_type: sql_template
    model_spec:
      single_sql: "select CAMPAIGN_PROFILE_ID, USER_MAIN_ID, ANONYMOUS_ID, UTM_CAMPAIGN, TIMESTAMP from MATERIAL_RSMARKETINGPAGES_VAR_TABLE_B5F7FCDD_1000"
      occurred_at_col: TIMESTAMP
      ids:
        - entity: user
          select: user_main_id
          type: rudder_id
        - entity: campaign
          select: campaign_profile_id
          type: rudder_id
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
