### PR TITLE
fix: fetching past predictions table not working in propensity model

### DIFF
--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -523,6 +523,7 @@ class CommonWarehouseConnector(Connector):
         lookahead_days: int,
         current_date: str,
         model_name: str,
+        model_hash: str,
         material_registry: str,
     ):
         past_predictions_end_date = utils.date_add(current_date, -lookahead_days)
@@ -531,7 +532,7 @@ class CommonWarehouseConnector(Connector):
         try:
             past_predictions_info = (
                 df[
-                    (df["model_name"] == model_name)
+                    (df["model_hash"] == model_hash)
                     & (df["model_type"] == "python_model")
                     & (
                         df["end_ts"].dt.date
@@ -543,7 +544,7 @@ class CommonWarehouseConnector(Connector):
             )
         except IndexError:
             raise Exception(
-                f"No past predictions found for model {model_name} before {past_predictions_end_date}"
+                f"No past predictions found with model hash {model_hash} before {past_predictions_end_date}"
             )
 
         predictions_table_name = (

--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -533,7 +533,6 @@ class CommonWarehouseConnector(Connector):
             past_predictions_info = (
                 df[
                     (df["model_hash"] == model_hash)
-                    & (df["model_type"] == "python_model")
                     & (
                         df["end_ts"].dt.date
                         == pd.to_datetime(past_predictions_end_date).date()

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -622,6 +622,7 @@ class Connector(ABC):
         lookahead_days: int,
         current_date: str,
         model_name: str,
+        model_hash: str,
         material_registry: str,
     ):
         pass

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -757,6 +757,7 @@ class SnowflakeConnector(Connector):
         lookahead_days: int,
         current_date: str,
         model_name: str,
+        model_hash: str,
         material_registry: str,
     ):
         past_predictions_end_date = utils.date_add(current_date, -lookahead_days)
@@ -764,7 +765,7 @@ class SnowflakeConnector(Connector):
 
         try:
             past_predictions_info = (
-                registry_df.filter(col("model_name") == model_name)
+                registry_df.filter(col("model_hash") == model_hash)
                 .filter(col("model_type") == "python_model")
                 .filter(to_date(col("end_ts")) == past_predictions_end_date)
                 .sort(F.col("creation_ts").desc())
@@ -772,7 +773,7 @@ class SnowflakeConnector(Connector):
             )
         except IndexError:
             raise Exception(
-                f"No past predictions found for model {model_name} before {past_predictions_end_date}"
+                f"No past predictions found with model hash {model_hash} before {past_predictions_end_date}"
             )
 
         predictions_table_name = (

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -766,7 +766,6 @@ class SnowflakeConnector(Connector):
         try:
             past_predictions_info = (
                 registry_df.filter(col("model_hash") == model_hash)
-                .filter(col("model_type") == "python_model")
                 .filter(to_date(col("end_ts")) == past_predictions_end_date)
                 .sort(F.col("creation_ts").desc())
                 .collect()[0]

--- a/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
+++ b/src/predictions/profiles_mlcorelib/ml_core/preprocess_and_predict.py
@@ -38,6 +38,7 @@ def preprocess_and_predict(
     output_tablename,
     connector: Connector,
     trainer: MLTrainer,
+    model_hash: str,
 ):
     """
     This function is responsible for preprocessing
@@ -226,6 +227,7 @@ def preprocess_and_predict(
             trainer.prediction_horizon_days,
             str(end_ts.date()),
             trainer.output_profiles_ml_model,
+            model_hash,
             whtService.get_registry_table_name(),
         )
 
@@ -315,6 +317,7 @@ if __name__ == "__main__":
     parser.add_argument("--merged_config", type=json.loads)
     parser.add_argument("--output_path", type=str)
     parser.add_argument("--mode", type=str)
+    parser.add_argument("--model_hash", type=str)
     args = parser.parse_args()
 
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -354,6 +357,9 @@ if __name__ == "__main__":
         logger.get().error(f"Error while parsing inputs: {e}")
         raise Exception(f"Error while parsing inputs: {e}")
 
+    if args.model_hash is None:
+        raise Exception("model_hash is required")
+
     _ = preprocess_and_predict(
         wh_creds,
         args.s3_config,
@@ -363,6 +369,7 @@ if __name__ == "__main__":
         args.output_tablename,
         connector=connector,
         trainer=trainer,
+        model_hash=args.model_hash,
     )
 
     if args.mode == constants.RUDDERSTACK_MODE:

--- a/src/predictions/profiles_mlcorelib/predict.py
+++ b/src/predictions/profiles_mlcorelib/predict.py
@@ -93,4 +93,5 @@ def _predict(
         output_tablename,
         merged_config,
         site_config,
+        whtService.get_model_hash(),
     )

--- a/src/predictions/profiles_mlcorelib/processors/K8sProcessor.py
+++ b/src/predictions/profiles_mlcorelib/processors/K8sProcessor.py
@@ -277,6 +277,7 @@ class K8sProcessor(Processor):
         merged_config: dict,
         site_config: dict,
         pkl_model_file_name: str,
+        model_hash: str,
     ):
         credentials_presets = site_config["py_models"]["credentials_presets"]
         k8s_config = credentials_presets["kubernetes"]
@@ -316,6 +317,8 @@ class K8sProcessor(Processor):
             json.dumps(merged_config),
             "--pkl_model_file_name",
             pkl_model_file_name,
+            "--model_hash",
+            model_hash,
         ]
         job_name = "ml-prediction-" + str(uuid.uuid4())
         self._execute(

--- a/src/predictions/profiles_mlcorelib/processors/LocalProcessor.py
+++ b/src/predictions/profiles_mlcorelib/processors/LocalProcessor.py
@@ -69,6 +69,7 @@ class LocalProcessor(Processor):
         output_tablename,
         merged_config,
         site_config: dict,
+        model_hash: str,
     ):
         output_path = os.path.dirname(model_path)
         json_output_filename = model_path.split("/")[-1]
@@ -97,6 +98,8 @@ class LocalProcessor(Processor):
             output_path,
             "--mode",
             constants.LOCAL_MODE,
+            "--model_hash",
+            model_hash,
         ]
         response_for_predict = utils.subprocess_run(commands)
         if response_for_predict.returncode != 0:

--- a/src/predictions/profiles_mlcorelib/processors/Processor.py
+++ b/src/predictions/profiles_mlcorelib/processors/Processor.py
@@ -43,5 +43,6 @@ class Processor(ABC):
         output_tablename,
         merged_config,
         site_config: dict,
+        model_hash: str,
     ):
         pass

--- a/src/predictions/profiles_mlcorelib/processors/SnowflakeProcessor.py
+++ b/src/predictions/profiles_mlcorelib/processors/SnowflakeProcessor.py
@@ -41,6 +41,7 @@ class SnowflakeProcessor(Processor):
         output_tablename,
         merged_config,
         site_config: dict,
+        model_hash: str,
     ):
         return preprocess_and_predict(
             creds,
@@ -51,4 +52,5 @@ class SnowflakeProcessor(Processor):
             output_tablename,
             connector=self.connector,
             trainer=self.trainer,
+            model_hash=model_hash,
         )

--- a/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
@@ -50,6 +50,11 @@ class PyNativeWHT:
 
         return str(start_date), str(end_date)
 
+    def get_model_hash(self) -> str:
+        # FIXME: Replace this method with model_hash function after pb 0.19 release
+        material_split = self.pythonWHT.split_material_name(self.whtMaterial.name())
+        return material_split["model_hash"]
+
     def get_latest_entity_var_table(self, entity_key: str) -> Tuple[str, str, str]:
         model_ref = f"entity/{entity_key}/var_table"
         material = self.whtMaterial.de_ref(model_ref)

--- a/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
@@ -49,6 +49,9 @@ class PythonWHT:
         current_timestamp = datetime.now()
         return str(current_timestamp)
 
+    def get_model_hash(self) -> str:
+        return "random_hash"
+
     def _getPB(self):
         mock = False
         if mock:


### PR DESCRIPTION
## Description of the change

- We had a check `model_type='python_model'` when fetching the past table. This wouldn't work for propensity model. So removed the check
- Checking for `model_name` is not correct since it is possible for multiple projects with the same model name to run in the same schema. So replaced it with `model_hash` check. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
