### PR TITLE
Added consent management for llm usage

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/attribution_report.py
@@ -617,8 +617,7 @@ class AttributionModelRecipe(PyNativeRecipe):
         try:
             this.de_ref(model_ref)
         except Exception:
-            # Note: Customer will still see error logs from wht side
-            self.logger.info(f"Skipping {model_ref} as it does not exist")
+            # Skipping model_ref as it does not exist
             return
         self.inputs.add(model_ref)
 

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/audit.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/audit.py
@@ -103,6 +103,7 @@ class ModelRecipe(PyNativeRecipe):
             self.reader,
             this,
             self.build_spec["access_token"],
+            self.logger,
             table_report,
             entity,
         )

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/audit.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/audit.py
@@ -63,9 +63,23 @@ class ModelRecipe(PyNativeRecipe):
         for model in models:
             id_stitcher_models[model.name()] = model
         if len(id_stitcher_models) > 1:
-            selected_model_name = self.reader.get_input(
-                f"Multiple id_stitcher models found. Please select one {id_stitcher_models.keys()}"
-            )
+            max_retries = 5
+            retry_count = 0
+            while retry_count < max_retries:
+                selected_model_name = self.reader.get_input(
+                    f"Multiple id_stitcher models found. Please select one {id_stitcher_models.keys()}"
+                ).strip()
+                if selected_model_name in id_stitcher_models:
+                    break
+                retry_count += 1
+                if retry_count < max_retries:
+                    self.logger.warn(
+                        f"Invalid selection: '{selected_model_name}'. Please enter one of the following: {list(id_stitcher_models.keys())}"
+                    )
+                else:
+                    raise ValueError(
+                        f"Max retries exceeded. No valid id-stitcher model selected."
+                    )
         else:
             selected_model_name = list(id_stitcher_models.keys())[0]
         self.id_stitcher_model = id_stitcher_models[selected_model_name]

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/consent_manager.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/consent_manager.py
@@ -1,4 +1,3 @@
-import os
 import json
 from pathlib import Path
 from typing import Union
@@ -11,7 +10,10 @@ class ConsentManager:
     LLM_CONSENT_KEY = "llm_consent"
     PREFERENCES_FILE = "preferences.json"
 
-    def __init__(self, config_dir: Path):
+    def __init__(self):
+        config_dir = Path.home() / ".pb"
+        if not config_dir.exists():
+            config_dir.mkdir(parents=True, exist_ok=True)
         self.consent_file = config_dir / self.PREFERENCES_FILE
 
     @property
@@ -31,9 +33,12 @@ class ConsentManager:
             with open(self.consent_file, "r") as f:
                 data = json.load(f)
                 return data.get(self.LLM_CONSENT_KEY, None)
-        except Exception:
+        except json.JSONDecodeError:
             # Delete existing file if it is corrupted
             self.consent_file.unlink(missing_ok=True)
+            return None
+        except Exception:
+            # For other exceptions, return None - assume prior consent doesn't exist
             return None
 
     def save_consent(self, consent: bool) -> None:

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/consent_manager.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/consent_manager.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from typing import Union
+from profiles_rudderstack.logger import Logger
 
 # TODO: Uncomment the following line after adding the Reader class to the profiles_rudderstack package
 # from profiles_rudderstack.reader import Reader
@@ -10,11 +11,12 @@ class ConsentManager:
     LLM_CONSENT_KEY = "llm_consent"
     PREFERENCES_FILE = "preferences.json"
 
-    def __init__(self):
+    def __init__(self, logger: Logger):
         config_dir = Path.home() / ".pb"
         if not config_dir.exists():
             config_dir.mkdir(parents=True, exist_ok=True)
         self.consent_file = config_dir / self.PREFERENCES_FILE
+        self.logger = logger
 
     @property
     def consent_message(self) -> str:
@@ -37,8 +39,11 @@ class ConsentManager:
             # Delete existing file if it is corrupted
             self.consent_file.unlink(missing_ok=True)
             return None
-        except Exception:
+        except Exception as e:
             # For other exceptions, return None - assume prior consent doesn't exist
+            self.logger.warn(
+                f"Error reading consent file {self.consent_file}: {e}. Asking for new consent."
+            )
             return None
 
     def save_consent(self, consent: bool) -> None:

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/consent_manager.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/consent_manager.py
@@ -1,0 +1,59 @@
+import os
+import json
+from pathlib import Path
+from typing import Union
+
+# TODO: Uncomment the following line after adding the Reader class to the profiles_rudderstack package
+# from profiles_rudderstack.reader import Reader
+
+
+class ConsentManager:
+    LLM_CONSENT_KEY = "llm_consent"
+    PREFERENCES_FILE = "preferences.json"
+
+    def __init__(self, config_dir: Path):
+        self.consent_file = config_dir / self.PREFERENCES_FILE
+
+    @property
+    def consent_message(self) -> str:
+        msg = f"""
+        This process includes LLM-based analysis which may send some of your text data to LLM providers Anthropic and OpenAI as part of the API calls. 
+        Would you like to proceed? This choice will be rememberd for future runs. (you can reset this choice by deleting the consent file at {self.consent_file})
+        This is an optional step and you can choose to not consent to LLM usage and continue with the analysis excluding the LLM-based analysis.
+        Do you consent to LLM usage? (yes/no): 
+        """
+        return msg
+
+    def get_stored_consent(self) -> Union[bool, None]:
+        try:
+            if not self.consent_file.exists():
+                return None
+            with open(self.consent_file, "r") as f:
+                data = json.load(f)
+                return data.get(self.LLM_CONSENT_KEY, None)
+        except Exception:
+            # Delete existing file if it is corrupted
+            self.consent_file.unlink(missing_ok=True)
+            return None
+
+    def save_consent(self, consent: bool) -> None:
+        self.consent_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.consent_file, "w") as f:
+            json.dump({self.LLM_CONSENT_KEY: consent}, f)
+
+    def prompt_for_consent(self, reader) -> bool:
+        retry_count = 0
+        while retry_count < 3:
+            response = reader.get_input(self.consent_message).lower().strip()
+            if response == "yes":
+                consent = True
+            elif response == "no":
+                consent = False
+            else:
+                retry_count += 1
+                print(f"Invalid response: {response}. Please enter 'yes' or 'no'.\n")
+                continue
+            self.save_consent(consent)
+            return consent
+        print("Max retries reached. Skipping LLM-based analysis for this run.")
+        return False

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/llm_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/llm_report.py
@@ -5,6 +5,7 @@ from profiles_rudderstack.material import WhtMaterial
 from .config import LLM_SERVICE_URL
 from .table_report import TableReport
 from .consent_manager import ConsentManager
+from profiles_rudderstack.logger import Logger
 
 # TODO: Uncomment the following line after adding the Reader class to the profiles_rudderstack package
 # from profiles_rudderstack.reader import Reader
@@ -21,6 +22,7 @@ class LLMReport:
         reader,
         this: WhtMaterial,
         access_token: str,
+        logger: Logger,
         table_report: TableReport,
         entity: Dict,
     ):
@@ -30,9 +32,10 @@ class LLMReport:
         self.reader = reader
         self.entity = entity
         self.session_id = ""
+        self.logger = logger
 
     def check_consent(self):
-        consent_manager = ConsentManager()
+        consent_manager = ConsentManager(self.logger)
         consent = consent_manager.get_stored_consent()
         if consent is None:
             consent = consent_manager.prompt_for_consent(self.reader)

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/llm_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/llm_report.py
@@ -8,7 +8,6 @@ from .consent_manager import ConsentManager
 
 # TODO: Uncomment the following line after adding the Reader class to the profiles_rudderstack package
 # from profiles_rudderstack.reader import Reader
-from pathlib import Path
 from enum import Enum
 
 
@@ -31,11 +30,9 @@ class LLMReport:
         self.reader = reader
         self.entity = entity
         self.session_id = ""
-        # Get config directory from siteconfig path
-        self.config_dir = Path(this.wht_ctx.site_config().get("FilePath")).parent
 
     def check_consent(self):
-        consent_manager = ConsentManager(self.config_dir)
+        consent_manager = ConsentManager()
         consent = consent_manager.get_stored_consent()
         if consent is None:
             consent = consent_manager.prompt_for_consent(self.reader)


### PR DESCRIPTION
Also added two other minor changes:
1. when the selected id stitcher model is not a valid selection (ex: an accidental enter would try to find an empty string in id stitcher model names), it prompts again for a valid selection - has a retry limit of 5
2. missed a review comment in a previous pr disabling a log. added that

## Description of the change

```
You can explore specific clusters by entering an ID to see how the other ids are all connected and the cluster is formed.
The ID can be either the main ID or any other ID type.
Enter an ID to visualize (or 'skip' to skip this step): 
skip
Exiting interactive mode.

        This process includes LLM-based analysis which may send some of your text data to LLM providers Anthropic and OpenAI as part of the API calls. 
        Would you like to proceed? This choice will be rememberd for future runs. (you can reset this choice by deleting the consent file at /Users/dileep/.pb/preferences.json)
        This is an optional step and you can choose to not consent to LLM usage and continue with the analysis excluding the LLM-based analysis.
        Do you consent to LLM usage? (yes/no): 
        
yes
You can now ask questions about the ID Stitcher analysis results.
```

If prev selection was no:

```
LLM-based analysis is disabled. Skipping LLM-based analysis.
```

We create a new file called `preferences.json` with following content, in the .pb folder:
`{"llm_consent": true}`

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
