### PR TITLE
Limited snowpark max version to below 1.26.0

### DIFF
--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "google-auth-oauthlib>=1.0.0",
     "cryptography>=42.0.2",
     "plotly>=5.24.1",
-    "snowflake-snowpark-python[pandas]>=1.11.1",
+    "snowflake-snowpark-python[pandas]>=1.11.1,<1.26.0",
     "networkx",
     "pyvis",
     "rudder-sdk-python",


### PR DESCRIPTION
## Description of the change

Snowpark 1.26.0 introduced a new method to get active session and that caused a regression in our prediction step in snowflake.
Limiting snowpark max version to address the issue. 

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
