### PR TITLE
replacing get_table() instances with run_query()

### DIFF
--- a/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
@@ -87,7 +87,7 @@ class BigQueryConnector(CommonWarehouseConnector):
         self, _: google.cloud.bigquery.client.Client, table_name: str, **kwargs
     ) -> pd.DataFrame:
         query = self._create_get_table_query(table_name, **kwargs)
-        return self._run_query(query).to_dataframe()
+        return self.run_query(query, return_type="dataframe")
 
     def get_tablenames_from_schema(self) -> pd.DataFrame:
         query = f"SELECT DISTINCT table_name as tablename FROM `{self.project_id}.{self.schema}.INFORMATION_SCHEMA.TABLES`;"

--- a/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
@@ -1,7 +1,7 @@
 import json
 import pandas as pd
 from collections import namedtuple
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Union
 
 import google.cloud
 from google.cloud import bigquery
@@ -63,7 +63,7 @@ class BigQueryConnector(CommonWarehouseConnector):
     def _run_query(self, query: str) -> google.cloud.bigquery.table.RowIterator:
         return self.session.query_and_wait(query)
 
-    def run_query(self, query: str, **kwargs) -> Optional[List]:
+    def run_query(self, query: str, **kwargs) -> Optional[Union[List, pd.DataFrame]]:
         """Runs the given query on the bigquery connection and returns a list with Named indices."""
         response = kwargs.get("response", True)
         return_type = kwargs.get("return_type", "sequence")

--- a/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
@@ -71,7 +71,7 @@ class BigQueryConnector(CommonWarehouseConnector):
         try:
             query_run_obj = self._run_query(query)
             if response:
-                if return_type == "pandas":
+                if return_type == "dataframe":
                     return query_run_obj.to_dataframe()
                 else:
                     return list(query_run_obj.to_dataframe().itertuples(index=False))

--- a/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/BigQueryConnector.py
@@ -60,10 +60,7 @@ class BigQueryConnector(CommonWarehouseConnector):
         )
         return session
 
-    def _run_query(
-        self, query: str, **kwargs
-    ) -> google.cloud.bigquery.table.RowIterator:
-        query = self._create_get_table_query(query, **kwargs)
+    def _run_query(self, query: str) -> google.cloud.bigquery.table.RowIterator:
         return self.session.query_and_wait(query)
 
     def run_query(self, query: str, **kwargs) -> Optional[List]:
@@ -72,7 +69,7 @@ class BigQueryConnector(CommonWarehouseConnector):
         return_type = kwargs.get("return_type", "sequence")
 
         try:
-            query_run_obj = self._run_query(query, **kwargs)
+            query_run_obj = self._run_query(query)
             if response:
                 if return_type == "pandas":
                     return query_run_obj.to_dataframe()
@@ -89,8 +86,8 @@ class BigQueryConnector(CommonWarehouseConnector):
     def get_table_as_dataframe(
         self, _: google.cloud.bigquery.client.Client, table_name: str, **kwargs
     ) -> pd.DataFrame:
-        query = f"SELECT * FROM {table_name}"
-        return self._run_query(query, **kwargs).to_dataframe()
+        query = self._create_get_table_query(table_name, **kwargs)
+        return self._run_query(query).to_dataframe()
 
     def get_tablenames_from_schema(self) -> pd.DataFrame:
         query = f"SELECT DISTINCT table_name as tablename FROM `{self.project_id}.{self.schema}.INFORMATION_SCHEMA.TABLES`;"

--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -253,9 +253,8 @@ class CommonWarehouseConnector(Connector):
         """Fetches the table with the given name from the schema as a pandas Dataframe object."""
         return self.get_table_as_dataframe(self.session, table_name, **kwargs)
 
-    def _create_get_table_query(self, table_name, **kwargs):
+    def _create_get_table_query(self, query, **kwargs):
         filter_condition = kwargs.get("filter_condition", "")
-        query = f"SELECT * FROM {table_name}"
         if filter_condition and filter_condition != "*":
             query += f" WHERE {filter_condition}"
         query += ";"
@@ -1057,7 +1056,7 @@ class CommonWarehouseConnector(Connector):
         pass
 
     @abstractmethod
-    def run_query(self, query: str, response: bool) -> Optional[Sequence]:
+    def run_query(self, query: str, **kwargs) -> Optional[Sequence]:
         pass
 
     @abstractmethod

--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -1049,7 +1049,7 @@ class CommonWarehouseConnector(Connector):
         pass
 
     @abstractmethod
-    def run_query(self, query: str, **kwargs) -> Optional[Sequence]:
+    def run_query(self, query: str, **kwargs) -> Optional[Union[List, pd.DataFrame]]:
         pass
 
     @abstractmethod

--- a/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/CommonWarehouseConnector.py
@@ -253,13 +253,6 @@ class CommonWarehouseConnector(Connector):
         """Fetches the table with the given name from the schema as a pandas Dataframe object."""
         return self.get_table_as_dataframe(self.session, table_name, **kwargs)
 
-    def _create_get_table_query(self, query, **kwargs):
-        filter_condition = kwargs.get("filter_condition", "")
-        if filter_condition and filter_condition != "*":
-            query += f" WHERE {filter_condition}"
-        query += ";"
-        return query
-
     def load_and_delete_json(self, json_file_name: str) -> dict:
         file_path = os.path.join(self.local_dir, json_file_name)
         with open(file_path, "r") as file:

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -311,7 +311,7 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def run_query(self, query: str, **kwargs) -> Optional[Sequence]:
+    def run_query(self, query: str, **kwargs):
         pass
 
     @abstractmethod

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -42,7 +42,7 @@ class Connector(ABC):
 
     def _create_get_table_query(self, table_name, **kwargs):
         filter_condition = kwargs.get("filter_condition", "")
-        query = f"SELECT * FROM {table_name}"
+        query = f"SELECT * FROM {self.schema}.{table_name}"
         if filter_condition and filter_condition != "*":
             query += f" WHERE {filter_condition}"
         return query

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -40,6 +40,13 @@ class Connector(ABC):
                 f"SQL model table {table_name} has duplicate values in entity column {entity_column}. Please make sure that the column {entity_column} in all SQL model has unique values only."
             )
 
+    def _create_get_table_query(self, table_name, **kwargs):
+        filter_condition = kwargs.get("filter_condition", "")
+        query = f"SELECT * FROM {table_name}"
+        if filter_condition and filter_condition != "*":
+            query += f" WHERE {filter_condition}"
+        return query
+
     def _validate_common_columns(
         self,
         columns_per_input: List[Set[str]],

--- a/src/predictions/profiles_mlcorelib/connectors/Connector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/Connector.py
@@ -304,7 +304,7 @@ class Connector(ABC):
         pass
 
     @abstractmethod
-    def run_query(self, query: str, response: bool) -> Optional[Sequence]:
+    def run_query(self, query: str, **kwargs) -> Optional[Sequence]:
         pass
 
     @abstractmethod

--- a/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
@@ -70,7 +70,7 @@ class RedshiftConnector(CommonWarehouseConnector):
 
         if response:
             query_run_obj = self._run_query(query)
-            if return_type == "pandas":
+            if return_type == "dataframe":
                 return query_run_obj.fetch_dataframe()
 
             if query_run_obj.description:
@@ -84,7 +84,7 @@ class RedshiftConnector(CommonWarehouseConnector):
                     "No result set is present for given query. Please check the query."
                 )
         else:
-            return self._run_query(query, **kwargs)
+            return self._run_query(query)
 
     def get_entity_var_table_ref(self, table_name: str) -> str:
         return f'"{self.schema}"."{table_name.lower()}"'

--- a/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
@@ -2,7 +2,7 @@ import json
 import inspect
 import pandas as pd
 from collections import namedtuple
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Union
 
 import redshift_connector
 import redshift_connector.cursor
@@ -63,7 +63,7 @@ class RedshiftConnector(CommonWarehouseConnector):
             self.session = self.build_session(self.creds)
             return self.session.execute(query)
 
-    def run_query(self, query: str, **kwargs) -> Optional[List]:
+    def run_query(self, query: str, **kwargs) -> Optional[Union[List, pd.DataFrame]]:
         """Runs the given query on the redshift connection and returns a Named Tuple."""
         response = kwargs.get("response", True)
         return_type = kwargs.get("return_type", "sequence")

--- a/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
@@ -55,8 +55,7 @@ class RedshiftConnector(CommonWarehouseConnector):
         session.execute(f"SET search_path TO {self.schema};")
         return session
 
-    def _run_query(self, query: str, **kwargs) -> redshift_connector.cursor.Cursor:
-        query = self._create_get_table_query(query, **kwargs)
+    def _run_query(self, query: str) -> redshift_connector.cursor.Cursor:
         try:
             return self.session.execute(query)
         except:
@@ -70,7 +69,7 @@ class RedshiftConnector(CommonWarehouseConnector):
         return_type = kwargs.get("return_type", "sequence")
 
         if response:
-            query_run_obj = self._run_query(query, **kwargs)
+            query_run_obj = self._run_query(query)
             if return_type == "pandas":
                 return query_run_obj.fetch_dataframe()
 
@@ -96,8 +95,8 @@ class RedshiftConnector(CommonWarehouseConnector):
     def get_table_as_dataframe(
         self, _: redshift_connector.cursor.Cursor, table_name: str, **kwargs
     ) -> pd.DataFrame:
-        query = f"SELECT * FROM {table_name}"
-        return self._run_query(query, **kwargs).fetch_dataframe()
+        query = self._create_get_table_query(table_name, **kwargs)
+        return self._run_query(query).fetch_dataframe()
 
     def get_tablenames_from_schema(self) -> pd.DataFrame:
         query = f"SELECT DISTINCT tablename FROM PG_TABLE_DEF WHERE schemaname = '{self.schema}';"

--- a/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/RedshiftConnector.py
@@ -96,7 +96,7 @@ class RedshiftConnector(CommonWarehouseConnector):
         self, _: redshift_connector.cursor.Cursor, table_name: str, **kwargs
     ) -> pd.DataFrame:
         query = self._create_get_table_query(table_name, **kwargs)
-        return self._run_query(query).fetch_dataframe()
+        return self.run_query(query, return_type="dataframe")
 
     def get_tablenames_from_schema(self) -> pd.DataFrame:
         query = f"SELECT DISTINCT tablename FROM PG_TABLE_DEF WHERE schemaname = '{self.schema}';"

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -100,7 +100,11 @@ class SnowflakeConnector(Connector):
 
     def run_query(self, query: str, **kwargs) -> List:
         """Runs the given query on the snowpark session and returns a List with Named indices."""
-        return self.session.sql(query).collect()
+        return_type = kwargs.get("return_type", "sequence")
+        query_run_obj = self.session.sql(query)
+        if return_type == "dataframe":
+            return query_run_obj
+        return query_run_obj.collect()
 
     def call_procedure(self, *args, **kwargs):
         """Calls the given procedure on the snowpark session and returns the results of the procedure call."""

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -183,13 +183,8 @@ class SnowflakeConnector(Connector):
         return has_entry
 
     def get_table(self, table_name: str, **kwargs) -> snowflake.snowpark.Table:
-        filter_condition = kwargs.get("filter_condition", None)
-        if not self.is_valid_table(table_name):
-            raise Exception(f"Table {table_name} does not exist or not authorized")
-        table = self.session.table(table_name)
-        if filter_condition and filter_condition != "*":
-            table = self.filter_table(table, filter_condition)
-        return table
+        query = self._create_get_table_query(table_name, **kwargs)
+        return self.session.sql(query)
 
     def get_table_as_dataframe(
         self, session: snowflake.snowpark.Session, table_name: str, **kwargs

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -186,9 +186,9 @@ class SnowflakeConnector(Connector):
         self.material_validity_cache[material_key] = has_entry
         return has_entry
 
-    def get_table(self, table_name: str, **kwargs) -> snowflake.snowpark.Table:
+    def get_table(self, table_name: str, **kwargs) -> snowflake.snowpark.DataFrame:
         query = self._create_get_table_query(table_name, **kwargs)
-        return self.session.sql(query)
+        return self.run_query(query, return_type="dataframe")
 
     def get_table_as_dataframe(
         self, session: snowflake.snowpark.Session, table_name: str, **kwargs

--- a/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
+++ b/src/predictions/profiles_mlcorelib/connectors/SnowflakeConnector.py
@@ -98,7 +98,7 @@ class SnowflakeConnector(Connector):
         """Joins the given file name to the local temp folder path."""
         return os.path.join(local_folder, file_name)
 
-    def run_query(self, query: str, **args) -> List:
+    def run_query(self, query: str, **kwargs) -> List:
         """Runs the given query on the snowpark session and returns a List with Named indices."""
         return self.session.sql(query).collect()
 


### PR DESCRIPTION
## Description of the change

> Ticket [link](https://linear.app/rudderstack/issue/PRML-1055/get-rid-of-get-table-function-entirely-in-propensity-models).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
