### PR TITLE
Reverted breaking changes from pb 0.20.0 to a compatible version with…

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/audit.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/audit.py
@@ -26,10 +26,12 @@ class AuditIdStitcherModel(BaseModelType):
     }
 
     def __init__(self, build_spec: dict, schema_version: int, pb_version: str) -> None:
-        build_spec["materialization"] = {
-            "output_type": "shell",
-            "run_type": "interactive",
-        }
+        # ToDo: Uncomment in 0.7.2
+        # build_spec["materialization"] = {
+        #     "output_type": "shell",
+        #     "run_type": "interactive",
+        # }
+        build_spec["materialization"] = {"output_type": "ephemeral"}
         super().__init__(build_spec, schema_version, pb_version)
         self.recipe = ModelRecipe(self.build_spec)
 

--- a/src/predictions/profiles_mlcorelib/py_native/propensity.py
+++ b/src/predictions/profiles_mlcorelib/py_native/propensity.py
@@ -94,16 +94,20 @@ class PropensityModel(BaseModelType):
         parent_folder: WhtFolder,
         model_name: str,
     ) -> None:
-        build_spec["materialization"] = {"output_type": "none"}
+        # ToDo: Uncomment and remove the ephemeral line for 0.7.2 release
+        # build_spec["materialization"] = {"output_type": "none"}
+        build_spec["materialization"] = {"output_type": "ephemeral"}
         super().__init__(build_spec, schema_version, pb_version)
         training_model_name = model_name + "_training"
         training_spec = self._get_training_spec()
         parent_folder.add_child_specs(
             training_model_name, "training_model", training_spec
         )
-        training_model_ref = (
-            f"{parent_folder.folder_ref_from_level_root()}/{training_model_name}"
-        )
+        # training_model_ref = (
+        #     f"{parent_folder.folder_ref_from_level_root()}/{training_model_name}"
+        # )
+        # ToDo: Uncomment the prev line for 0.7.2 and remove below line
+        training_model_ref = "models/" + training_model_name
         prediction_spec = self._get_prediction_spec(training_model_ref, training_spec)
         parent_folder.add_child_specs(
             model_name + "_prediction",

--- a/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pyNativeWHT.py
@@ -139,9 +139,11 @@ class PyNativeWHT:
             column_name = None
             if material.model.materialization()["output_type"] == "column":
                 column_name = material.model.db_object_name_prefix()
-                table_material_ref = (
-                    material.model.encapsulating_model().model_ref_from_level_root()
-                )
+                # table_material_ref = (
+                #     material.model.encapsulating_model().model_ref_from_level_root()
+                # )
+                # ToDo: Uncomment above line and remove the next line for 0.7.2
+                table_material_ref = material.model.encapsulating_model().model_ref()
                 table_material = self.whtMaterial.de_ref(table_material_ref)
             else:
                 table_material = material

--- a/src/predictions/setup.py
+++ b/src/predictions/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from version import version
 
 install_requires = [
-    "profiles_rudderstack>=0.19.0",
+    "profiles_rudderstack>=0.19.0,<0.20.0",
     "cachetools>=5.3.2",
     "hyperopt>=0.2.7",
     "joblib>=1.3.2",


### PR DESCRIPTION
… 0.19.0

## Description of the change
* Reverted breaking changes from 0.20.0 - and pinned setup.py to <0.20.0 so anyone without latest pb will have 0.7.1
* Will revert these in 0.7.2 with a min version in setup.py for profiles-rudderstack

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
