### PR TITLE
Skipping parts of id stitcher audit steps if only a single id type exists

### DIFF
--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/cluster_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/cluster_report.py
@@ -389,6 +389,11 @@ class ClusterReport:
         return f"rgba{rgb + (opacity,)}"
 
     def run(self):
+        if len(self.table_report.analysis_results["node_types"]) <= 1:
+            print(
+                "The ID stitcher has only a single ID type. Skipping cluster analysis."
+            )
+            return
         print(
             "You can explore specific clusters by entering an ID to see how the other ids are all connected and the cluster is formed."
         )

--- a/src/predictions/profiles_mlcorelib/py_native/id_stitcher/table_report.py
+++ b/src/predictions/profiles_mlcorelib/py_native/id_stitcher/table_report.py
@@ -507,7 +507,8 @@ class TableReport:
                 f"{id_type}: {count} nodes ({round(count/self.analysis_results['unique_id_counts'][id_type] * 100, 2)}%) not connected to any other ID type"
             )
 
-        # Check for potential issues
-        potential_issues = self.check_for_issues(node_types)
-        self.analysis_results["potential_issues"] = potential_issues
+        if len(node_types) > 1:
+            # Check for potential issues
+            potential_issues = self.check_for_issues(node_types)
+            self.analysis_results["potential_issues"] = potential_issues
         print(f"\n\nANALYSIS COMPLETE FOR ENTITY: {entity_key}\n\n")

--- a/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
@@ -312,6 +312,7 @@ class PythonWHT:
 
         materialise_data = True
         for date in [feature_date, label_date]:
+            # ToDo: Check if we are honoring material registry table at this point. we are likely generating it even if the data exists on this date.
             if date is not None:
                 self.run(feature_package_path, date)
 

--- a/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
+++ b/src/predictions/profiles_mlcorelib/wht/pythonWHT.py
@@ -312,7 +312,7 @@ class PythonWHT:
 
         materialise_data = True
         for date in [feature_date, label_date]:
-            # ToDo: Check if we are honoring material registry table at this point. we are likely generating it even if the data exists on this date.
+            # TODO: Check if we are honoring material registry table at this point. we are likely generating it even if the data exists on this date.
             if date is not None:
                 self.run(feature_package_path, date)
 


### PR DESCRIPTION

## Description of the change

In Audit id stitcher, we were making a few assumptions around the number of id types. For cases with a single id type, this is resulting in bugs. Fixed the issue by skipping the additional audit for such scenarios, as a single id type does not really need these steps. 

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
