### PR TITLE
making campaign_vars and campaign_details optional in attribution model

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,8 +155,6 @@ jobs:
             site_config: SNOWFLAKE_SITE_CONFIG
           - test: tests/integration/attribution/attribution.py
             site_config: REDSHIFT_SITE_CONFIG_V2
-          - test: tests/integration/attribution/attribution.py
-            site_config: BIGQUERY_SITE_CONFIG
 
     steps:
     - name: Check out code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,6 +155,8 @@ jobs:
             site_config: SNOWFLAKE_SITE_CONFIG
           - test: tests/integration/attribution/attribution.py
             site_config: REDSHIFT_SITE_CONFIG_V2
+          - test: tests/integration/attribution/attribution.py
+            site_config: BIGQUERY_SITE_CONFIG
 
     steps:
     - name: Check out code

--- a/samples/attribution_project/models/attribution.yaml
+++ b/samples/attribution_project/models/attribution.yaml
@@ -129,6 +129,27 @@ models:
                 date: date 
                 select: sum(reach)
 
+  - name: campaign_performance_report_optional
+    model_type: attribution
+    model_spec:
+      entity_key: user
+      conversion:
+        touchpoints:
+          - from: models/rsRandomSQLModel
+            where: timestamp > {{user.Var('first_order_date')}}
+          - from: inputs/rsMarketingPages
+            where: timestamp > {{user.Var('first_order_date')}}
+        conversion_vars:
+          - name: sf_order
+            timestamp: user.Var('first_order_date')
+            value: user.Var('first_invoice_amount')
+          - name: sf_subscription
+            timestamp: user.Var('subscription_start_date')
+      campaign:
+        entity_key: campaign
+        campaign_start_date: campaign_start_date
+        campaign_end_date: campaign_end_date
+
 # Defining Features For Campaigns
 var_groups:
   - name: campaign_vars


### PR DESCRIPTION
## Description of the change

> Ticket [Link](https://linear.app/rudderstack/issue/PRML-1129/make-campaign-vars-and-campaign-details-optional-in-attribution-models).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
